### PR TITLE
Fix upload in ie and safari

### DIFF
--- a/src/IframeUploader.jsx
+++ b/src/IframeUploader.jsx
@@ -83,6 +83,9 @@ var IframeUploader = React.createClass({
   _onChange: function(e) {
     this.startUpload = true;
     this.file = (e.target.files && e.target.files[0]) || e.target;
+    // ie8/9 don't support FileList Object
+    // http://stackoverflow.com/questions/12830058/ie8-input-type-file-get-files
+    this.file.name = this.file.name || e.target.value;
     this.props.onStart(this.file);
     React.findDOMNode(this.refs.form).submit();
   },

--- a/src/IframeUploader.jsx
+++ b/src/IframeUploader.jsx
@@ -29,10 +29,13 @@ var IframeUploader = React.createClass({
 
   componentDidMount: function() {
     var el = React.findDOMNode(this);
-    this.setState({
-      width: el.offsetWidth,
-      height: el.offsetHeight
-    });
+    // Fix render bug in IE
+    setTimeout(() => {
+      this.setState({
+        width: el.offsetWidth,
+        height: el.offsetHeight
+      });
+    }, 0);
   },
 
   _getName: function() {

--- a/src/Upload.jsx
+++ b/src/Upload.jsx
@@ -37,7 +37,7 @@ var Upload = React.createClass({
     var props = this.props;
     var isNode = typeof window === 'undefined';
     // node环境或者支持FormData的情况使用AjaxUpload
-    if (isNode || typeof FormData === 'function') {
+    if (isNode || typeof FormData !== undefined) {
       return <AjaxUpload {...props} />;
     }
 


### PR DESCRIPTION
1. 修复 ie8/9 拿不到 file.name 的问题。
2. 修复 ie8/9 下 input[type=file] 高度不对的问题。
3. 修复 safari 下进入了 iframe 模式的问题。（safari 下 typeof FormData 为 object）