### PR TITLE
Added aria role and keyboard navigation.

### DIFF
--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -22,6 +22,12 @@ const AjaxUploader = React.createClass({
     el.value = '';
   },
 
+  onKeyDown(e) {
+    if (e.key === 'Enter') {
+      this._onClick();
+    }
+  },
+
   onFileDrop(e) {
     if (e.type === 'dragover') {
       return e.preventDefault();
@@ -37,7 +43,7 @@ const AjaxUploader = React.createClass({
     const hidden = {display: 'none'};
     const props = this.props;
     return (
-      <span onClick={this.onClick} onDrop={this.onFileDrop} onDragOver={this.onFileDrop}>
+      <span onClick={this.onClick} onKeyDown={this.onKeyDown} onDrop={this.onFileDrop} onDragOver={this.onFileDrop} role="button" tabIndex="0">
         <input type="file"
                ref="file"
                style={hidden}


### PR DESCRIPTION
The role-attribute is important when we make "none-interactive"
elements interactive, such as SPANs. This makes it easier for
person using screen readers and such to use the site.
(http://www.w3.org/TR/wai-aria/roles)

By having a tabIndex and support "enter" we can easily navigate
to the upload element, and enter it via the keyboard. This makes
our site more usable.