### PR TITLE
Update IframeUploader.jsx

### DIFF
--- a/src/IframeUploader.jsx
+++ b/src/IframeUploader.jsx
@@ -43,6 +43,9 @@ const IframeUploader = React.createClass({
         doc.body.removeChild(script);
       }
       response = doc.body.innerHTML;
+      if (response.slice(0, 5).toLowerCase()  == "<pre>") { // Some browsers return result in a <pre> tag.
+        response = JSON.parse(doc.body.firstChild.firstChild.nodeValue);
+      }
       props.onSuccess(response, eventFile);
     } catch (err) {
       warning(false, 'cross domain error for Upload. Maybe server should return document.domain script. see Note from https://github.com/react-component/upload');


### PR DESCRIPTION
Modification of data for onSuccess, since some browsers return the information in a <pre> tag. I've seen this behaviour in IE9.

Haven't looked at the code in detail, so don't know if you expect the server to return JSON-data as in the modified code.