### PR TITLE
xhr with credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-upload",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "upload ui component for react",
   "keywords": [
     "react",

--- a/src/request.js
+++ b/src/request.js
@@ -55,6 +55,8 @@ export default function upload(option) {
     option.onSuccess(getBody(xhr));
   };
 
+  xhr.withCredentials = true;
+
   xhr.open('post', option.action, true);
   xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
   xhr.send(formData);


### PR DESCRIPTION
Fix the problem that the uploading would fail if the server requires login by setting xhr with credentials,
[#26](https://github.com/react-component/upload/issues/26).