### PR TITLE
把 file 传给 data 方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ React.render(<Upload />, container);
 |-----|---|--------|----|
 |name | string | file| file param post to server |
 |action| string | | from action url |
-|data| object | | other data object to post |
+|data| object/function(file) | | other data object to post or a function which returns a data object |
 |headers| object | {} | http headers to post, available in modern browsers |
 |accept | string | | input accept attribute |
 |forceAjax | bool | | force to use ajax render. used for server render |

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -82,7 +82,7 @@ const AjaxUploader = React.createClass({
     const props = this.props;
     let data = props.data;
     if (typeof data === 'function') {
-      data = data();
+      data = data(file);
     }
 
     request({

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -6,7 +6,10 @@ const AjaxUploader = React.createClass({
   propTypes: {
     multiple: PropTypes.bool,
     onStart: PropTypes.func,
-    data: PropTypes.object,
+    data: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.func,
+    ]),
     headers: PropTypes.object,
     beforeUpload: PropTypes.func,
     withCredentials: PropTypes.bool,

--- a/src/IframeUploader.jsx
+++ b/src/IframeUploader.jsx
@@ -69,7 +69,7 @@ const IframeUploader = React.createClass({
     const dataSpan = this.getFormDataNode();
     let data = this.props.data;
     if (typeof data === 'function') {
-      data = data();
+      data = data(file);
     }
     const inputs = [];
     for (const key in data) {

--- a/src/IframeUploader.jsx
+++ b/src/IframeUploader.jsx
@@ -15,7 +15,10 @@ const IframeUploader = React.createClass({
     onStart: PropTypes.func,
     multiple: PropTypes.bool,
     children: PropTypes.any,
-    data: PropTypes.object,
+    data: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.func,
+    ]),
     action: PropTypes.string,
     name: PropTypes.string,
   },

--- a/src/Upload.jsx
+++ b/src/Upload.jsx
@@ -15,7 +15,10 @@ const Upload = React.createClass({
     onSuccess: PropTypes.func,
     onProgress: PropTypes.func,
     onStart: PropTypes.func,
-    data: PropTypes.object,
+    data: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.func,
+    ]),
     headers: PropTypes.object,
     accept: PropTypes.string,
     multiple: PropTypes.bool,


### PR DESCRIPTION
像阿里云的 OSS 需要把文件名放在 data 里，我们会把上传的文件名换成成 UUID，所以我希望能在 data 里拿到上传的文件对象，然后根据上传文件的后缀生成新的文件名。

顺便改正了 data 的 prop 验证。