### PR TITLE
feat(request): fix issue #33 and #34

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "http://github.com/react-component/upload/issues"
   },
-  "licenses": "MIT",
+  "license": "MIT",
   "files": [
     "lib"
   ],
@@ -47,7 +47,8 @@
     "rc-tools": "4.x",
     "react": "0.14.x",
     "react-addons-test-utils": "~0.14.0",
-    "react-dom": "0.14.x"
+    "react-dom": "0.14.x",
+    "sinon": "^1.17.3"
   },
   "pre-commit": [
     "lint"

--- a/src/request.js
+++ b/src/request.js
@@ -50,7 +50,9 @@ export default function upload(option) {
   };
 
   xhr.onload = function onload() {
-    if (xhr.status !== 200) {
+    // allow success when 2xx status
+    // see https://github.com/react-component/upload/issues/34
+    if (xhr.status < 200 || xhr.status >= 300) {
       return option.onError(getError(option, xhr), getBody(xhr));
     }
 
@@ -65,10 +67,16 @@ export default function upload(option) {
     xhr.withCredentials = true;
   }
 
-  xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
   const headers = option.headers || {};
+
+  // when set headers['X-Requested-With'] = null , can close default XHR header
+  // see https://github.com/react-component/upload/issues/33
+  if (headers['X-Requested-With'] !== null) {
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+  }
+
   for (const h in headers) {
-    if (headers.hasOwnProperty(h)) {
+    if (headers.hasOwnProperty(h) && headers[h] !== null) {
       xhr.setRequestHeader(h, headers[h]);
     }
   }

--- a/src/request.js
+++ b/src/request.js
@@ -20,6 +20,17 @@ function getBody(xhr) {
   }
 }
 
+// option {
+//  onProgress: (event: { percent: number }): void,
+//  onError: (event: Error, body?: Object): void,
+//  onSuccess: (body: Object): void,
+//  data: Object,
+//  filename: String,
+//  file: File,
+//  withCredentials: Boolean,
+//  action: String,
+//  headers: Object,
+// }
 export default function upload(option) {
   if (typeof XMLHttpRequest === 'undefined') {
     return;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -9,6 +9,8 @@ const ReactDOM = require('react-dom');
 const TestUtils = require('react-addons-test-utils');
 const Simulate = TestUtils.Simulate;
 
+import './request.spec';
+
 describe('uploader', function() {
   describe('ajax uploader', function() {
     if (typeof FormData === 'undefined') {

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -1,0 +1,83 @@
+
+import expect from 'expect.js';
+import request from '../src/request';
+import sinon from 'sinon';
+
+let xhr, requests;
+
+const empty = function() {};
+const option = {
+  onSuccess: empty,
+  action: 'upload.do',
+  data: { a: 1, b: 2 },
+  filename: 'a.png',
+  file: 'foo',
+  headers: { from: 'hello' },
+};
+
+describe('request', function() {
+  beforeEach(function() {
+    xhr = sinon.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = function (req) { requests.push(req); };
+  });
+
+  afterEach(function() {
+    xhr.restore();
+  });
+
+  beforeEach(function() {
+    option.onError = empty;
+    option.onSuccess = empty;
+  });
+
+  it('upload request success', function(done) {
+    option.onError = done;
+    option.onSuccess = function(ret) {
+      expect(ret).to.eql({ success: true });
+      done();
+    };
+    request(option);
+    requests[0].respond(200, {}, '{"success": true}');
+  });
+
+  it('2xx code should be success', function(done) {
+    option.onError = done;
+    option.onSuccess = function(ret) {
+      expect(ret).to.equal('');
+      done();
+    };
+    request(option);
+    requests[0].respond(204, {});
+  });
+
+  it('30x code should be error', function(done) {
+    option.onError = function(e) {
+      expect(e.toString()).to.contain('304')
+      done();
+    };
+
+    option.onSuccess = function(ret) {
+      done('304 should throw error');
+    };
+    request(option);
+    requests[0].respond(304, {}, 'Not Modified');
+  });
+
+  it('get headers', function() {
+    request(option);
+    expect(requests[0].requestHeaders).to.eql({
+      'X-Requested-With': 'XMLHttpRequest',
+      from: 'hello',
+    });
+  });
+
+  it('can empty X-Requested-With', function() {
+    option.headers['X-Requested-With'] = null;
+    request(option);
+    expect(requests[0].requestHeaders).to.eql({
+      from: 'hello',
+    });
+  });
+
+});

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -3,9 +3,10 @@ import expect from 'expect.js';
 import request from '../src/request';
 import sinon from 'sinon';
 
-let xhr, requests;
+let xhr;
+let requests;
 
-const empty = function() {};
+const empty = () => {};
 const option = {
   onSuccess: empty,
   action: 'upload.do',
@@ -15,25 +16,25 @@ const option = {
   headers: { from: 'hello' },
 };
 
-describe('request', function() {
-  beforeEach(function() {
+describe('request', () => {
+  beforeEach(() => {
     xhr = sinon.useFakeXMLHttpRequest();
     requests = [];
-    xhr.onCreate = function (req) { requests.push(req); };
+    xhr.onCreate = req => requests.push(req);
   });
 
-  afterEach(function() {
+  afterEach(() => {
     xhr.restore();
   });
 
-  beforeEach(function() {
+  beforeEach(() => {
     option.onError = empty;
     option.onSuccess = empty;
   });
 
-  it('upload request success', function(done) {
+  it('upload request success', done => {
     option.onError = done;
-    option.onSuccess = function(ret) {
+    option.onSuccess = ret => {
       expect(ret).to.eql({ success: true });
       done();
     };
@@ -41,9 +42,9 @@ describe('request', function() {
     requests[0].respond(200, {}, '{"success": true}');
   });
 
-  it('2xx code should be success', function(done) {
+  it('2xx code should be success', done => {
     option.onError = done;
-    option.onSuccess = function(ret) {
+    option.onSuccess = ret => {
       expect(ret).to.equal('');
       done();
     };
@@ -51,20 +52,18 @@ describe('request', function() {
     requests[0].respond(204, {});
   });
 
-  it('30x code should be error', function(done) {
-    option.onError = function(e) {
-      expect(e.toString()).to.contain('304')
+  it('30x code should be error', done => {
+    option.onError = e => {
+      expect(e.toString()).to.contain('304');
       done();
     };
 
-    option.onSuccess = function(ret) {
-      done('304 should throw error');
-    };
+    option.onSuccess = () => done('304 should throw error');
     request(option);
     requests[0].respond(304, {}, 'Not Modified');
   });
 
-  it('get headers', function() {
+  it('get headers', () => {
     request(option);
     expect(requests[0].requestHeaders).to.eql({
       'X-Requested-With': 'XMLHttpRequest',
@@ -72,12 +71,9 @@ describe('request', function() {
     });
   });
 
-  it('can empty X-Requested-With', function() {
+  it('can empty X-Requested-With', () => {
     option.headers['X-Requested-With'] = null;
     request(option);
-    expect(requests[0].requestHeaders).to.eql({
-      from: 'hello',
-    });
+    expect(requests[0].requestHeaders).to.eql({ from: 'hello' });
   });
-
 });


### PR DESCRIPTION
1. allow all 2xx status as success status, not only 200
2. can close X-Requested-With header when set value as null

closes #33 #34 

cc @yiminghe @afc163 