### PR TITLE
修复单选时可以拖拽多个文件的问题

### DIFF
--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -65,17 +65,21 @@ const AjaxUploader = React.createClass({
   },
 
   uploadFiles(files) {
-    const len = files.length;
+    let postFiles = Array.prototype.slice.call(files);
+    if (!this.props.multiple) {
+      postFiles = postFiles.slice(0, 1);
+    }
+    const len = postFiles.length;
     if (len > 0) {
       for (let i = 0; i < len; i++) {
-        const file = files.item(i);
+        const file = postFiles[i];
         file.uid = uid();
         this.upload(file);
       }
       if (this.props.multiple) {
-        this.props.onStart(Array.prototype.slice.call(files));
+        this.props.onStart(postFiles);
       } else {
-        this.props.onStart(Array.prototype.slice.call(files)[0]);
+        this.props.onStart(postFiles[0]);
       }
     }
   },


### PR DESCRIPTION
之前的代码拖拽时还是可以上传多个文件，并触发 before 事件