### PR TITLE
add custom request option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ React.render(<Upload />, container);
 |onSuccess | function | | success callback |
 |onProgress | function || progress callback, only for modern browsers|
 |beforeUpload| function |null| before upload check, return false or a rejected Promise will stop upload, only for modern browsers|
+|customRequest | function | null | provide an override for the default xhr behavior for additional customization|
 |withCredentials | boolean | false | ajax upload with cookie send |
 
 #### onError arguments
@@ -82,6 +83,23 @@ React.render(<Upload />, container);
 
 1. `result`: request body
 2. `file`: upload file
+
+
+### customRequest
+
+Allows for advanced customization by overriding default behavior in AjaxUplaoder. Provide your own XMLHttpRequest calls to interface with custom backend processes or interact with AWS S3 service through the aws-sdk-js package.
+
+customRequest callback is passed an object with:
+
+* `onProgress: (event: { percent: number }): void`
+* `onError: (event: Error, body?: Object): void`
+* `onSuccess: (body: Object): void`
+* `data: Object`
+* `filename: String`
+* `file: File`
+* `withCredentials: Boolean`
+* `action: String`
+* `headers: Object`
 
 
 ### methods

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -2,7 +2,7 @@
 
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import request from './request';
+import defaultRequest from './request';
 import getUid from './uid';
 
 const AjaxUploader = React.createClass({
@@ -22,6 +22,7 @@ const AjaxUploader = React.createClass({
     ]),
     headers: PropTypes.object,
     beforeUpload: PropTypes.func,
+    customRequest: PropTypes.func,
     withCredentials: PropTypes.bool,
   },
 
@@ -111,6 +112,7 @@ const AjaxUploader = React.createClass({
       data = data(file);
     }
     const { uid } = file;
+    const request = props.customRequest || defaultRequest;
     this.reqs[uid] = request({
       action: props.action,
       filename: props.name,

--- a/src/Upload.jsx
+++ b/src/Upload.jsx
@@ -26,6 +26,7 @@ const Upload = React.createClass({
     multiple: PropTypes.bool,
     disabled: PropTypes.bool,
     beforeUpload: PropTypes.func,
+    customRequest: PropTypes.func,
     onReady: PropTypes.func,
     withCredentials: PropTypes.bool,
     supportServerRender: PropTypes.bool,
@@ -47,6 +48,7 @@ const Upload = React.createClass({
       supportServerRender: false,
       multiple: false,
       beforeUpload: null,
+      customRequest: null,
       withCredentials: false,
     };
   },


### PR DESCRIPTION
I found myself needing to change portions of the AjaxUploader component to get it working with AWS S3. Allowing for the component to have a custom request prop would make extensibility easier.