### PR TITLE
bugfix: split script close tag for html file inline usage

### DIFF
--- a/src/IframeUploader.jsx
+++ b/src/IframeUploader.jsx
@@ -126,7 +126,8 @@ const IframeUploader = React.createClass({
     let domainScript = '';
     let domainInput = '';
     if (domain) {
-      domainScript = `<script>document.domain="${domain}";</script>`;
+      const script = 'script';
+      domainScript = `<${script}>document.domain="${domain}";</${script}>`;
       domainInput = `<input name="_documentDomain" value="${domain}" />`;
     }
     return `


### PR DESCRIPTION
For instance:

```html
<script>
... domainScript = '<script>document.domain="' + domain + '"</script>'
</script>
```

The close tag `</script>` in template string will break javaScript engine, so we need to use a variable to split it.