### PR TITLE
Fix crash if customRequest does not call onSuccess() / onError()

### DIFF
--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -154,7 +154,7 @@ const AjaxUploader = React.createClass({
       }
     } else {
       Object.keys(reqs).forEach((uid) => {
-        reqs[uid].abort();
+        if( reqs[uid] ) reqs[uid].abort();
         delete reqs[uid];
       });
     }


### PR DESCRIPTION
The component is currently a bit fragile: If a customRequest does not call `onSuccess()` / `onError()` upon completion or error, the `this.reqs[uid]` value will not be deleted, but === undefined, and then when the Upload component un-mounts, it will try to `abort()` an undefined request, and crash.