### PR TITLE
Fix abort error when using custom request

### DIFF
--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -155,16 +155,19 @@ class AjaxUploader extends Component {
         uid = file.uid;
       }
       if (reqs[uid]) {
-        reqs[uid].abort();
+        if (typeof reqs[uid].abort === 'function') {
+          reqs[uid].abort();
+        }
         delete reqs[uid];
       }
     } else {
       Object.keys(reqs).forEach((uid) => {
         if (reqs[uid]) {
-          reqs[uid].abort();
+          if (typeof reqs[uid].abort === 'function') {
+            reqs[uid].abort();
+          }
+          delete reqs[uid];
         }
-
-        delete reqs[uid];
       });
     }
   }


### PR DESCRIPTION
The request in `reqs[uid] ` may not get a standard instance of `request` while calling `customRequest` function which returns a Promise.

Checking `abort` function before being called could solve this scenario. 