### PR TITLE
make attr-accept inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "lint"
   ],
   "dependencies": {
-    "attr-accept": "^1.1.0",
     "babel-runtime": "6.x",
     "classnames": "^2.2.5",
     "warning": "2.x",

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import defaultRequest from './request';
 import getUid from './uid';
-import attrAccept from 'attr-accept';
+import attrAccept from './attr-accept';
 
 class AjaxUploader extends Component {
   static propTypes = {

--- a/src/attr-accept.js
+++ b/src/attr-accept.js
@@ -1,0 +1,26 @@
+function endsWith(str, suffix) {
+  return str.indexOf(suffix, str.length - suffix.length) !== -1;
+}
+
+export default (file, acceptedFiles) => {
+  if (file && acceptedFiles) {
+    const acceptedFilesArray = Array.isArray(acceptedFiles)
+      ? acceptedFiles
+      : acceptedFiles.split(',');
+    const fileName = file.name || '';
+    const mimeType = file.type || '';
+    const baseMimeType = mimeType.replace(/\/.*$/, '');
+
+    return acceptedFilesArray.some(type => {
+      const validType = type.trim();
+      if (validType.charAt(0) === '.') {
+        return endsWith(fileName.toLowerCase(), validType.toLowerCase());
+      } else if (/\/\*$/.test(validType)) {
+        // This is something like a image/* mime type
+        return baseMimeType === validType.replace(/\/.*$/, '');
+      }
+      return mimeType === validType;
+    });
+  }
+  return true;
+};


### PR DESCRIPTION
Inline the  attr-accept to avoid import dist files compiled by babel5.

close ant-design/ant-design#8210

close https://github.com/ant-design/ant-design/issues/7515