### PR TITLE
support id prop

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -80,12 +80,15 @@ class Test extends React.Component {
         >
           <Upload
             {...this.uploaderProps}
+            id="test"
             component="div"
             style={{ display: 'inline-block' }}
           >
             <a>开始上传2</a>
           </Upload>
         </div>
+
+        <label htmlFor="test">Label for Upload</label>
       </div>
 
       <button onClick={this.destroy}>destroy</button>

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -10,6 +10,7 @@ import traverseFileTree from './traverseFileTree';
 
 class AjaxUploader extends Component {
   static propTypes = {
+    id: PropTypes.string,
     component: PropTypes.string,
     style: PropTypes.object,
     prefixCls: PropTypes.string,
@@ -197,7 +198,7 @@ class AjaxUploader extends Component {
 
   render() {
     const {
-      component: Tag, prefixCls, className, disabled,
+      component: Tag, prefixCls, className, disabled, id,
       style, multiple, accept, children, directory, openFileDialogOnClick,
     } = this.props;
     const cls = classNames({
@@ -220,6 +221,7 @@ class AjaxUploader extends Component {
         style={style}
       >
         <input
+          id={id}
           type="file"
           ref={this.saveFileInput}
           key={this.state.uid}

--- a/tests/uploader.spec.js
+++ b/tests/uploader.spec.js
@@ -101,6 +101,13 @@ describe('uploader', () => {
       ReactDOM.unmountComponentAtNode(node);
     });
 
+    it('with id', (done) => {
+      ReactDOM.render(<Uploader id="bamboo" />, node, function init() {
+        expect(TestUtils.findRenderedDOMComponentWithTag(this, 'input').id).to.be('bamboo');
+        done();
+      });
+    });
+
     it('create works', () => {
       expect(TestUtils.scryRenderedDOMComponentsWithTag(uploader, 'span').length).to.be(1);
     });


### PR DESCRIPTION
User can pass `id` to internal `input` element.

ref: https://github.com/ant-design/ant-design/issues/13036