### PR TITLE
Added openFileDialogOnClick

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 # History
 ----
 
+- Add `openFileDialogOnEnter`.
+
 ### 2.6.0 / 2018-09-21
 
 - Add `openFileDialogOnClick`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ React.render(<Upload />, container);
 |customRequest | function | null | provide an override for the default xhr behavior for additional customization|
 |withCredentials | boolean | false | ajax upload with cookie send |
 |openFileDialogOnClick | boolean | true |  |
+|openFileDialogOnEnter | boolean | true | useful for drag only upload as it does not trigger on enter key |
 
 #### onError arguments
 

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -35,6 +35,7 @@ class AjaxUploader extends Component {
     onProgress: PropTypes.func,
     withCredentials: PropTypes.bool,
     openFileDialogOnClick: PropTypes.bool,
+    openFileDialogOnEnter: PropTypes.bool,
   }
 
   state = { uid: getUid() }
@@ -200,6 +201,7 @@ class AjaxUploader extends Component {
     const {
       component: Tag, prefixCls, className, disabled, id,
       style, multiple, accept, children, directory, openFileDialogOnClick,
+      openFileDialogOnEnter,
     } = this.props;
     const cls = classNames({
       [prefixCls]: true,
@@ -207,8 +209,8 @@ class AjaxUploader extends Component {
       [className]: className,
     });
     const events = disabled ? {} : {
-      onClick: openFileDialogOnClick ? this.onClick : () => { },
-      onKeyDown: this.onKeyDown,
+      onClick: openFileDialogOnClick ? this.onClick: () => { },
+      onKeyDown: openFileDialogOnEnter ? this.onKeyDown: () => { },
       onDrop: this.onFileDrop,
       onDragOver: this.onFileDrop,
       tabIndex: '0',

--- a/src/Upload.jsx
+++ b/src/Upload.jsx
@@ -36,6 +36,7 @@ class Upload extends Component {
     withCredentials: PropTypes.bool,
     supportServerRender: PropTypes.bool,
     openFileDialogOnClick: PropTypes.bool,
+    openFileDialogOnEnter: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -55,6 +56,7 @@ class Upload extends Component {
     customRequest: null,
     withCredentials: false,
     openFileDialogOnClick: true,
+    openFileDialogOnEnter: true,
   }
 
   state = {


### PR DESCRIPTION
This is useful if one for example wants to add drag and drop upload to a editor component, where the enter key is used for new lines.