### PR TITLE
Fix: preprocess filelist, add uid before calling upload

### DIFF
--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -93,11 +93,15 @@ class AjaxUploader extends Component {
 
   uploadFiles = (files) => {
     const postFiles = Array.prototype.slice.call(files);
-    postFiles.forEach((file) => {
-      file.uid = getUid();
-      this.upload(file, postFiles);
-    });
-  }
+    postFiles
+      .map(file => {
+        file.uid = getUid();
+        return file;
+      })
+      .forEach(file => {
+        this.upload(file, postFiles);
+      });
+  };
 
   upload(file, fileList) {
     const { props } = this;


### PR DESCRIPTION
Code in antd [here](https://github.com/ant-design/ant-design/blob/master/components/upload/Upload.tsx#L219) assumes that every file in `fileList: RcFile[]` has `uid` property.

When passes prop `beforeUpload` function to antd's `Upload` component and the  `beforeUpload` function returns false, react will throw a unique key error due to the lack of `uid`(antd's `UploadList` component [use `uid` as unique key](https://github.com/ant-design/ant-design/blob/master/components/upload/UploadList.tsx#L198)). 