### PR TITLE
feat(ajaxUploader): add transformFile option for transform file before request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn.lock
 es
 package-lock.json
 tmp/
+.history

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ React.render(<Upload />, container);
 |customRequest | function | null | provide an override for the default xhr behavior for additional customization|
 |withCredentials | boolean | false | ajax upload with cookie send |
 |openFileDialogOnClick | boolean | true | useful for drag only upload as it does not trigger on enter key or click event |
+|transformFile | function(file): Promise&lt;blob&gt; |  | transform file before request |
 
 #### onError arguments
 

--- a/examples/transformFile.html
+++ b/examples/transformFile.html
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/transformFile.js
+++ b/examples/transformFile.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Upload from 'rc-upload';
-import axios from 'axios';
 
 const uploadProps = {
   action: '/upload.do',
@@ -23,44 +22,21 @@ const uploadProps = {
   onProgress({ percent }, file) {
     console.log('onProgress', `${percent}%`, file.name);
   },
-  customRequest({
-    action,
-    data,
-    file,
-    filename,
-    headers,
-    onError,
-    onProgress,
-    onSuccess,
-    withCredentials,
-  }) {
-    // EXAMPLE: post form-data with 'axios'
-    const formData = new FormData();
-    if (data) {
-      Object.keys(data).forEach(key => {
-        formData.append(key, data[key]);
-      });
-    }
-    formData.append(filename, file);
-
-    axios
-      .post(action, formData, {
-        withCredentials,
-        headers,
-        onUploadProgress: ({ total, loaded }) => {
-          onProgress({ percent: Math.round(loaded / total * 100).toFixed(2) }, file);
-        },
-      })
-      .then(({ data: response }) => {
-        onSuccess(response, file);
-      })
-      .catch(onError);
-
-    return {
-      abort() {
-        console.log('upload progress is aborted.');
-      },
-    };
+  transformFile(file) {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => {
+        const canvas = document.createElement('canvas');
+        const img = document.createElement('img');
+        img.src = reader.result;
+        img.onload = () => {
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, 0, 0);
+          canvas.toBlob(resolve);
+        };
+      };
+    });
   },
 };
 

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -161,19 +161,19 @@ class AjaxUploader extends Component {
           headers: props.headers,
           withCredentials: props.withCredentials,
           onProgress: onProgress ? e => {
-            onProgress(e, file, transformedFile);
+            onProgress(e, file);
           } : null,
           onSuccess: (ret, xhr) => {
             delete this.reqs[uid];
-            props.onSuccess(ret, file, xhr, transformedFile);
+            props.onSuccess(ret, file, xhr);
           },
           onError: (err, ret) => {
             delete this.reqs[uid];
-            props.onError(err, ret, file, transformedFile);
+            props.onError(err, ret, file);
           },
         };
         this.reqs[uid] = request(requestOption);
-        onStart(file, transformedFile);
+        onStart(file);
       });
     });
   }

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -136,7 +136,7 @@ class AjaxUploader extends Component {
     const {
       onStart,
       onProgress,
-      transformFile = () => Promise.resolve(file),
+      transformFile = (originFile) => originFile,
     } = props;
 
     if (typeof data === 'function') {

--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -35,6 +35,7 @@ class AjaxUploader extends Component {
     onProgress: PropTypes.func,
     withCredentials: PropTypes.bool,
     openFileDialogOnClick: PropTypes.bool,
+    transformFile: PropTypes.func,
   }
 
   state = { uid: getUid() }
@@ -132,7 +133,12 @@ class AjaxUploader extends Component {
     }
     const { props } = this;
     let { data } = props;
-    const { onStart, onProgress } = props;
+    const {
+      onStart,
+      onProgress,
+      transformFile = () => Promise.resolve(file),
+    } = props;
+
     if (typeof data === 'function') {
       data = data(file);
     }
@@ -145,26 +151,30 @@ class AjaxUploader extends Component {
     }).then(action => {
       const { uid } = file;
       const request = props.customRequest || defaultRequest;
-      this.reqs[uid] = request({
-        action,
-        filename: props.name,
-        file,
-        data,
-        headers: props.headers,
-        withCredentials: props.withCredentials,
-        onProgress: onProgress ? e => {
-          onProgress(e, file);
-        } : null,
-        onSuccess: (ret, xhr) => {
-          delete this.reqs[uid];
-          props.onSuccess(ret, file, xhr);
-        },
-        onError: (err, ret) => {
-          delete this.reqs[uid];
-          props.onError(err, ret, file);
-        },
+      const transform = Promise.resolve(transformFile(file));
+      transform.then((transformedFile) => {
+        const requestOption = {
+          action,
+          filename: props.name,
+          data,
+          file: transformedFile,
+          headers: props.headers,
+          withCredentials: props.withCredentials,
+          onProgress: onProgress ? e => {
+            onProgress(e, file, transformedFile);
+          } : null,
+          onSuccess: (ret, xhr) => {
+            delete this.reqs[uid];
+            props.onSuccess(ret, file, xhr, transformedFile);
+          },
+          onError: (err, ret) => {
+            delete this.reqs[uid];
+            props.onError(err, ret, file, transformedFile);
+          },
+        };
+        this.reqs[uid] = request(requestOption);
+        onStart(file, transformedFile);
       });
-      onStart(file);
     });
   }
 

--- a/src/request.js
+++ b/src/request.js
@@ -46,7 +46,7 @@ export default function upload(option) {
   const formData = new FormData();
 
   if (option.data) {
-    Object.keys(option.data).map(key => {
+    Object.keys(option.data).forEach(key => {
       formData.append(key, option.data[key]);
     });
   }

--- a/tests/uploader.spec.js
+++ b/tests/uploader.spec.js
@@ -339,61 +339,13 @@ describe('uploader', () => {
       ReactDOM.unmountComponentAtNode(node);
     });
 
-    it('receive transformed file after request', (done) => {
-      const handlers = {};
-      const props = {
-        action: '/test',
-        onStart(file, transformedFile) {
-          if (handlers.onStart) {
-            handlers.onStart(transformedFile);
-          }
-        },
-        onSuccess(ret, file, _, transformedFile) {
-          if (handlers.onSuccess) {
-            handlers.onSuccess(transformedFile);
-          }
-        },
-        transformFile(file) {
-          return Promise.resolve(Buffer.from(Array.from(file)));
-        },
-      };
-      ReactDOM.render(<Uploader {...props} />, node, function init() {
-        uploader = this;
-        const input = TestUtils.findRenderedDOMComponentWithTag(uploader, 'input');
-
-        const files = [{
-          name: 'success.png',
-          toString() {
-            return this.name;
-          },
-        }];
-
-        files.item = (i) => files[i];
-
-        handlers.onStart = (transformedFile) => {
-          expect(Buffer.isBuffer(transformedFile)).to.eql(true);
-        };
-
-        handlers.onSuccess = (transformedFile) => {
-          expect(Buffer.isBuffer(transformedFile)).to.eql(true);
-          done();
-        };
-
-        Simulate.change(input, { target: { files } });
-
-        setTimeout(() => {
-          requests[0].respond(200, {}, `["","${files[0].name}"]`);
-        }, 100);
-      });
-    });
-
     it('noes not affect receive origin file when transform file is null', (done) => {
       const handlers = {};
       const props = {
         action: '/test',
-        onSuccess(ret, file, _, transformedFile) {
+        onSuccess(ret, file) {
           if (handlers.onSuccess) {
-            handlers.onSuccess(ret, file, transformedFile);
+            handlers.onSuccess(ret, file);
           }
         },
         transformFile() {
@@ -413,10 +365,9 @@ describe('uploader', () => {
 
         files.item = (i) => files[i];
 
-        handlers.onSuccess = (ret, file, transformedFile) => {
+        handlers.onSuccess = (ret, file) => {
           expect(ret[1]).to.eql(file.name);
           expect(file).to.have.property('uid');
-          expect(transformedFile).to.eql(null);
           done();
         };
 

--- a/tests/uploader.spec.js
+++ b/tests/uploader.spec.js
@@ -321,4 +321,111 @@ describe('uploader', () => {
       }, 100);
     });
   });
+
+  describe('transform file before request', () => {
+    let node;
+    let uploader;
+    beforeEach((done) => {
+      node = document.createElement('div');
+      document.body.appendChild(node);
+
+      ReactDOM.render(<Uploader />, node, function init() {
+        uploader = this;
+        done();
+      });
+    });
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(node);
+    });
+
+    it('receive transformed file after request', (done) => {
+      const handlers = {};
+      const props = {
+        action: '/test',
+        onStart(file, transformedFile) {
+          if (handlers.onStart) {
+            handlers.onStart(transformedFile);
+          }
+        },
+        onSuccess(ret, file, _, transformedFile) {
+          if (handlers.onSuccess) {
+            handlers.onSuccess(transformedFile);
+          }
+        },
+        transformFile(file) {
+          return Promise.resolve(Buffer.from(Array.from(file)));
+        },
+      };
+      ReactDOM.render(<Uploader {...props} />, node, function init() {
+        uploader = this;
+        const input = TestUtils.findRenderedDOMComponentWithTag(uploader, 'input');
+
+        const files = [{
+          name: 'success.png',
+          toString() {
+            return this.name;
+          },
+        }];
+
+        files.item = (i) => files[i];
+
+        handlers.onStart = (transformedFile) => {
+          expect(Buffer.isBuffer(transformedFile)).to.eql(true);
+        };
+
+        handlers.onSuccess = (transformedFile) => {
+          expect(Buffer.isBuffer(transformedFile)).to.eql(true);
+          done();
+        };
+
+        Simulate.change(input, { target: { files } });
+
+        setTimeout(() => {
+          requests[0].respond(200, {}, `["","${files[0].name}"]`);
+        }, 100);
+      });
+    });
+
+    it('noes not affect receive origin file when transform file is null', (done) => {
+      const handlers = {};
+      const props = {
+        action: '/test',
+        onSuccess(ret, file, _, transformedFile) {
+          if (handlers.onSuccess) {
+            handlers.onSuccess(ret, file, transformedFile);
+          }
+        },
+        transformFile() {
+          return null;
+        },
+      };
+      ReactDOM.render(<Uploader {...props} />, node, function init() {
+        uploader = this;
+        const input = TestUtils.findRenderedDOMComponentWithTag(uploader, 'input');
+
+        const files = [{
+          name: 'success.png',
+          toString() {
+            return this.name;
+          },
+        }];
+
+        files.item = (i) => files[i];
+
+        handlers.onSuccess = (ret, file, transformedFile) => {
+          expect(ret[1]).to.eql(file.name);
+          expect(file).to.have.property('uid');
+          expect(transformedFile).to.eql(null);
+          done();
+        };
+
+        Simulate.change(input, { target: { files } });
+
+        setTimeout(() => {
+          requests[0].respond(200, {}, `["","${files[0].name}"]`);
+        }, 100);
+      });
+    });
+  });
 });


### PR DESCRIPTION
你好! 我想增加一个 `transformFile` 的接口, 由于 `antd` `Uploader` 组件使用是此 `repo` 所以在这里发起一个 `pr`

### 业务背景

普通的图片上传需求 由于业务需要 在 上传的时候 需要在原图片上增加水印 (前端canvas 增加) , 可以使用 `customRequest` 实现类似的需求, 就像 你们给的 [这个例子](https://github.com/react-component/upload/blob/master/examples/customRequest.js)

```js
    const formData = new FormData();
    if (data) {
      Object.keys(data).map(key => {
        formData.append(key, data[key]);
      });
    }

    // 但是其实我只需要替换掉这里的 file
    formData.append(filename, file);
    axios
      .post(action, formData, {
        withCredentials,
        headers,
        onUploadProgress: ({ total, loaded }) => {
          onProgress({ percent: Math.round(loaded / total * 100).toFixed(2) }, file);
        },
      })
      .then(({ data: response }) => {
        onSuccess(response, file);
      })
      .catch(onError);
```


### 为什么?

其实我只需要 在 你们的 `request.js`  替换到这里的 `file` 变量 , 不需要单独实现请求, 和手动调用 类似 `onSuccess` `onError` 的回调

```js
    formData.append(filename, file);
```

### 实现的效果

```jsx
import Upload from 'rc-upload';

const uploadProps = {
  action: '/upload.do',
  transformFile(file) {
    return new Promise((res) => {
      const reader = new FileReader()
      reader.readAsDataURL(file)
      reader.onload = () => {
        const canvas = document.createElement('canvas')
        const img = document.createElement('img')
        img.src = reader.result
        img.onload = () => {
          const ctx = canvas.getContext('2d')
          ctx.drawImage(img, 0, 0)
          ctx.drawImage(水印)
          canvas.toBlob(res)
        }
      }
    })
  },
};

const Test = () => {
  return (
        <Upload {...uploadProps}>
          <button>开始上传</button>
        </Upload>
  );
};
```

由于是有一些异步操作, 所以需要 返回 一个 `Promise` 这样 上传之前 我就可以把 当前的 `FileList` 替换掉  即

```
    formData.append(filename, blob);
```

谢谢!