### PR TITLE
fix: pass `transformedFile` to `onStart`

### DIFF
--- a/src/AjaxUploader.jsx
+++ b/src/AjaxUploader.jsx
@@ -159,7 +159,7 @@ class AjaxUploader extends Component {
           },
         };
         this.reqs[uid] = request(requestOption);
-        onStart(file);
+        onStart(transformedFile);
       });
     });
   }


### PR DESCRIPTION
the `transformedFile` is passed to `request(requestOption)`
but not the `onStart`.