### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,9 @@
       "\\.tsx?$": "./node_modules/rc-tools/scripts/jestPreprocessor.js",
       "\\.jsx?$": "./node_modules/rc-tools/scripts/jestPreprocessor.js"
     }
+  },
+  "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   }
 }


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
