### PR TITLE
chore: accept should skip when select files rather than dir

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -32,8 +32,11 @@ class AjaxUploader extends Component<UploadProps> {
   private _isMounted: boolean;
 
   onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { accept, directory } = this.props;
     const { files } = e.target;
-    const acceptedFiles = [...files].filter((file: RcFile) => attrAccept(file, this.props.accept));
+    const acceptedFiles = [...files].filter(
+      (file: RcFile) => !directory || attrAccept(file, accept),
+    );
     this.uploadFiles(acceptedFiles);
     this.reset();
   };

--- a/tests/uploader.spec.js
+++ b/tests/uploader.spec.js
@@ -460,12 +460,12 @@ describe('uploader', () => {
       },
     };
 
-    function test(desc, value, files, expectCallTimes, errorMessage) {
+    function test(desc, value, files, expectCallTimes, errorMessage, extraProps) {
       it(desc, done => {
         resetWarned();
         const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        uploader = mount(<Uploader {...props} accept={value} />);
+        uploader = mount(<Uploader {...props} {...extraProps} accept={value} />);
         const input = uploader.find('input').first();
         input.simulate('change', { target: { files } });
         const mockStart = jest.fn();
@@ -632,6 +632,26 @@ describe('uploader', () => {
       ],
       2,
       "Warning: Upload takes an invalidate 'accept' type 'jpg'.Skip for check.",
+    );
+
+    test(
+      'should skip when select file',
+      '.png',
+      [
+        {
+          name: 'accepted.png',
+          type: 'image/png',
+        },
+        {
+          name: 'unaccepted.text',
+          type: 'text/plain',
+        },
+      ],
+      2,
+      '',
+      {
+        directory: false,
+      },
     );
   });
 


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/30403

**改动点:**

触发 `onChange` 的时候，只有选择目录的时候，使用 `accept` 过滤文件，否则直接放行。