### PR TITLE
support and compatibel with aws.s3.putObjectApi upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ React.render(<Upload />, container);
 |component | "div"|"span" | "span"| wrap component name |
 |action| string &#124; function(file): string &#124; Promise&lt;string&gt; | | form action url |
 |method | string | post | request method |
+|processData | boolean | true | serialization form data(send only file object, do not send file related information) |
 |directory| boolean | false | support upload whole directory |
 |data| object/function(file) | | other data object to post or a function which returns a data object(a promise object which resolve a data object) |
 |headers| object | {} | http headers to post, available in modern browsers |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-upload",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "upload ui component for react",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "upload ui component for react",
   "keywords": [
     "react",
-    "react-component",
+    "sia-fl",
     "react-upload",
     "upload"
   ],
-  "homepage": "http://github.com/react-component/upload",
+  "homepage": "http://github.com/sia-fl/upload",
   "repository": {
     "type": "git",
-    "url": "git@github.com:react-component/upload.git"
+    "url": "git@github.com:sia-fl/upload.git"
   },
   "bugs": {
-    "url": "http://github.com/react-component/upload/issues"
+    "url": "http://github.com/sia-fl/upload/issues"
   },
   "license": "MIT",
   "files": [

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -196,7 +196,8 @@ class AjaxUploader extends Component<UploadProps> {
       return;
     }
 
-    const { onStart, customRequest, name, headers, withCredentials, method } = this.props;
+    const { onStart, customRequest, name, headers, withCredentials, method, processData } =
+      this.props;
 
     const { uid } = origin;
     const request = customRequest || defaultRequest;
@@ -209,6 +210,7 @@ class AjaxUploader extends Component<UploadProps> {
       headers,
       withCredentials,
       method: method || 'post',
+      processData: processData || true,
       onProgress: (e: UploadProgressEvent) => {
         const { onProgress } = this.props;
         onProgress?.(e, parsedFile);

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -13,6 +13,7 @@ export interface UploadProps
   component?: React.JSXElementConstructor<any>;
   action?: Action;
   method?: UploadRequestMethod;
+  processData?: boolean;
   directory?: boolean;
   data?: object | ((file: RcFile | string | Blob) => object);
   headers?: UploadRequestHeader;
@@ -64,6 +65,7 @@ export interface UploadRequestOption<T = any> {
   action: string;
   headers?: UploadRequestHeader;
   method: UploadRequestMethod;
+  processData: boolean;
 }
 
 export interface RcFile extends File {

--- a/src/request.ts
+++ b/src/request.ts
@@ -35,33 +35,6 @@ export default function upload(option: UploadRequestOption) {
     };
   }
 
-  // eslint-disable-next-line no-undef
-  const formData = new FormData();
-
-  if (option.data) {
-    Object.keys(option.data).forEach(key => {
-      const value = option.data[key];
-      // support key-value array data
-      if (Array.isArray(value)) {
-        value.forEach(item => {
-          // { list: [ 11, 22 ] }
-          // formData.append('list[]', 11);
-          formData.append(`${key}[]`, item);
-        });
-        return;
-      }
-
-      formData.append(key, option.data[key]);
-    });
-  }
-
-  // eslint-disable-next-line no-undef
-  if (option.file instanceof Blob) {
-    formData.append(option.filename, option.file, (option.file as any).name);
-  } else {
-    formData.append(option.filename, option.file);
-  }
-
   xhr.onerror = function error(e) {
     option.onError(e);
   };
@@ -97,7 +70,37 @@ export default function upload(option: UploadRequestOption) {
     }
   });
 
-  xhr.send(formData);
+  if (option.method.toLowerCase() === 'put' && option.processData === false) {
+    xhr.send(option.file);
+  } else {
+    // eslint-disable-next-line no-undef
+    const formData = new FormData();
+
+    if (option.data) {
+      Object.keys(option.data).forEach(key => {
+        const value = option.data[key];
+        // support key-value array data
+        if (Array.isArray(value)) {
+          value.forEach(item => {
+            // { list: [ 11, 22 ] }
+            // formData.append('list[]', 11);
+            formData.append(`${key}[]`, item);
+          });
+          return;
+        }
+
+        formData.append(key, option.data[key]);
+      });
+    }
+
+    // eslint-disable-next-line no-undef
+    if (option.file instanceof Blob) {
+      formData.append(option.filename, option.file, (option.file as any).name);
+    } else {
+      formData.append(option.filename, option.file);
+    }
+    xhr.send(formData);
+  }
 
   return {
     abort() {


### PR DESCRIPTION
when uploading files using aws.s3.putObjectApi, i need to give up "post" and use "put" method, the server where read all files stream contents, including “WebKitFormBoundary”, and final uploaded file content is inconsistent or the file is damaged.