### PR TITLE
fix:complete the function of 'accept' option

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -35,7 +35,7 @@ class AjaxUploader extends Component<UploadProps> {
     const { accept, directory } = this.props;
     const { files } = e.target;
     const acceptedFiles = [...files].filter(
-      (file: RcFile) => !directory || attrAccept(file, accept),
+      (file: RcFile) => !directory && attrAccept(file, accept),
     );
     this.uploadFiles(acceptedFiles);
     this.reset();


### PR DESCRIPTION
```js
const uploaderProps = {
  action: '/upload.do',
  data: { a: 1, b: 2 },
  multiple: true,
  beforeUpload(file) {
    console.log('beforeUpload', file.name);
  },
  onStart: file => {
    console.log('onStart', file.name);
  },
  onSuccess(file) {
    console.log('onSuccess', file);
  },
  onProgress(step, file) {
    console.log('onProgress', Math.round(step.percent), file.name);
  },
  onError(err) {
    console.log('onError', err);
  },
  capture: 'user',
  accept:'.jpg',
  directory: false
};
```
when I try to upload pictures in .jpg format, pictures in .png format can also be uploaded,and I try to solve this problem,here is my programme
```js
 onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
    const { accept, directory } = this.props;
    const { files } = e.target;
    const acceptedFiles = [...files].filter(
      (file: RcFile) => !directory && attrAccept(file, accept),
    );
    this.uploadFiles(acceptedFiles);
    this.reset();
  };
```
