### PR TITLE
feat: add showOpenFilePicker method

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ customRequest callback is passed an object with:
 
 abort(file?: File) => void: abort the uploading file
 
+showOpenFilePicker() => void: open file picker
+
 ## License
 
 rc-upload is released under the MIT license.

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -41,6 +41,10 @@ class AjaxUploader extends Component<UploadProps> {
     this.reset();
   };
 
+  showOpenFilePicker = () => {
+    this.fileInput?.click();
+  };
+
   onClick = (e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
     const el = this.fileInput;
     if (!el) {

--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -29,6 +29,10 @@ class Upload extends Component<UploadProps> {
     this.uploader.abort(file);
   }
 
+  showOpenFilePicker() {
+    this.uploader.showOpenFilePicker();
+  }
+
   saveUploader = (node: AjaxUpload) => {
     this.uploader = node;
   };


### PR DESCRIPTION
见到挺多人有这样的需求的，比较方便  https://github.com/ant-design/ant-design/discussions/41902

叫 `showOpenFilePicker` 是因为 window 下的方法也叫这个

like https://github.com/react-dropzone/react-dropzone#using-open-on-click