### PR TITLE
fix: pass disabled prop to input

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -302,6 +302,7 @@ class AjaxUploader extends Component<UploadProps> {
         <input
           {...pickAttrs(otherProps, { aria: true, data: true })}
           id={id}
+          disabled={disabled}
           type="file"
           ref={this.saveFileInput}
           onClick={e => e.stopPropagation()} // https://github.com/ant-design/ant-design/issues/19948


### PR DESCRIPTION
fix https://github.com/react-component/upload/issues/488

并且能防止用户通过 js 打开上传文件框