### PR TITLE
feat: remove uid

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -235,6 +235,8 @@ class AjaxUploader extends Component<UploadProps> {
     this.setState({
       uid: getUid(),
     });
+    // After changing here, can uid be removed?
+    if (this.fileInput) this.fileInput.value = "";
   }
 
   abort(file?: any) {


### PR DESCRIPTION
在每次上传结束后，清空input的值，而不是用uid来每次更新，这样可以删除大量关于uid的hack代码，并利用缓存，包含暂停请求等。
因为涉及量改动较大，故提个建议。如果需要我来支持，我可以帮忙删除，但程序可能不健壮，需要相当的测试案例。