### PR TITLE
fix: File upload components can still select files in the Safari browser

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -285,9 +285,9 @@ class AjaxUploader extends Component<UploadProps> {
     // because input don't have directory/webkitdirectory type declaration
     // detect if it's a Safari browser
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    const safariAccept = isSafari ? ".folder" : undefined
+    const safariAccept = isSafari ? ".safaribrowserdisabledselectfile" : undefined
     const dirProps: any = directory
-      ? { directory: 'directory', webkitdirectory: 'webkitdirectory', accept: safariAccept }
+      ? { directory: 'directory', webkitdirectory: 'webkitdirectory', accept: safariAccept  }
       : {};
     const events = disabled
       ? {}

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -283,8 +283,11 @@ class AjaxUploader extends Component<UploadProps> {
       [className]: className,
     });
     // because input don't have directory/webkitdirectory type declaration
+    // detect if it's a Safari browser
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    const safariAccept = isSafari ? ".folder" : undefined
     const dirProps: any = directory
-      ? { directory: 'directory', webkitdirectory: 'webkitdirectory', accept: ".folder" }
+      ? { directory: 'directory', webkitdirectory: 'webkitdirectory', accept: safariAccept }
       : {};
     const events = disabled
       ? {}

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -283,11 +283,8 @@ class AjaxUploader extends Component<UploadProps> {
       [className]: className,
     });
     // because input don't have directory/webkitdirectory type declaration
-    // detect if it's a Safari browser
-    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    const safariAccept = isSafari ? ".safaribrowserdisabledselectfile" : undefined
     const dirProps: any = directory
-      ? { directory: 'directory', webkitdirectory: 'webkitdirectory', accept: safariAccept  }
+      ? { directory: 'directory', webkitdirectory: 'webkitdirectory', accept: `.${'n'.repeat(10)}`  }
       : {};
     const events = disabled
       ? {}

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -284,7 +284,7 @@ class AjaxUploader extends Component<UploadProps> {
     });
     // because input don't have directory/webkitdirectory type declaration
     const dirProps: any = directory
-      ? { directory: 'directory', webkitdirectory: 'webkitdirectory' }
+      ? { directory: 'directory', webkitdirectory: 'webkitdirectory', accept: ".folder" }
       : {};
     const events = disabled
       ? {}


### PR DESCRIPTION
File upload components can still select files in the Safari browser

fix ant-design/ant-design#44170