### PR TITLE
fix: gracefully handle null items

### DIFF
--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -36,6 +36,9 @@ function loopFiles(item: InternalDataTransferItem, callback) {
 const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepted) => {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const _traverseFileTree = (item: InternalDataTransferItem, path?: string) => {
+    if (!item) {
+      return;
+    }
     // eslint-disable-next-line no-param-reassign
     item.path = path || '';
     if (item.isFile) {

--- a/tests/uploader.spec.js
+++ b/tests/uploader.spec.js
@@ -395,6 +395,22 @@ describe('uploader', () => {
       }, 100);
     });
 
+    it('dragging and dropping a non file with a file does not prevent the file from being uploaded', done => {
+      const input = uploader.find('input').first();
+      const file = {
+        name: 'success.png',
+      };
+      input.simulate('drop', {
+        dataTransfer: { items: [{ webkitGetAsEntry: () => null }, makeDataTransferItem(file)] },
+      });
+      const mockStart = jest.fn();
+      handlers.onStart = mockStart;
+      setTimeout(() => {
+        expect(mockStart.mock.calls.length).toBe(1);
+        done();
+      }, 100);
+    });
+
     it('unaccepted type files to upload will not trigger onStart when select directory', done => {
       const input = uploader.find('input').first();
       const files = [


### PR DESCRIPTION
Per the [DataTransferItem API](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry), if `webkitGetAsEntry()` is called on something that isn't a file or folder, null is returned. Sometimes when dragging and dropping a file, extra string meta data seems to be associated with the event (examples, dragging and dropping an image blob from a different browser tab, or dragging a message from the Outlook desktop app).
![image](https://github.com/react-component/upload/assets/7489744/cede0782-b257-46c9-808b-401dbe8bb705)

![image](https://github.com/react-component/upload/assets/7489744/84e1a722-6cfd-4ecb-ab12-76db4ab4d941)

![image](https://github.com/react-component/upload/assets/7489744/f090feed-ea27-4fce-8260-94ec7fa595e4)

 This causes an exception to be thrown, because the `_traverseFileTree` function assumes each item to be a valid `InternalDataTransferItem`. The end result is any valid file in the items array will not get uploaded after this exception occurs. If we can instead gracefully handle this case, valid directories will still get crawled and valid files will still get uploaded.

fix #514 
