### PR TITLE
fix:Press Tab twice to focus on the upload button

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -169,7 +169,7 @@ class AjaxUploader extends Component<UploadProps> {
       // string type is from legacy `transformFile`.
       // Not sure if this will work since no related test case works with it
       (typeof transformedFile === 'object' || typeof transformedFile === 'string') &&
-      transformedFile
+        transformedFile
         ? transformedFile
         : file;
 
@@ -291,14 +291,13 @@ class AjaxUploader extends Component<UploadProps> {
     const events = disabled
       ? {}
       : {
-          onClick: openFileDialogOnClick ? this.onClick : () => {},
-          onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => {},
-          onMouseEnter,
-          onMouseLeave,
-          onDrop: this.onFileDrop,
-          onDragOver: this.onFileDrop,
-          tabIndex: '0',
-        };
+        onClick: openFileDialogOnClick ? this.onClick : () => { },
+        onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => { },
+        onMouseEnter,
+        onMouseLeave,
+        onDrop: this.onFileDrop,
+        onDragOver: this.onFileDrop,
+      };
     return (
       <Tag {...events} className={cls} role="button" style={style}>
         <input

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -291,8 +291,8 @@ class AjaxUploader extends Component<UploadProps> {
     const events = disabled
       ? {}
       : {
-          onClick: openFileDialogOnClick ? this.onClick : () => { },
-          onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => { },
+          onClick: openFileDialogOnClick ? this.onClick : () => {},
+          onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => {},
           onMouseEnter,
           onMouseLeave,
           onDrop: this.onFileDrop,

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -169,7 +169,7 @@ class AjaxUploader extends Component<UploadProps> {
       // string type is from legacy `transformFile`.
       // Not sure if this will work since no related test case works with it
       (typeof transformedFile === 'object' || typeof transformedFile === 'string') &&
-        transformedFile
+      transformedFile
         ? transformedFile
         : file;
 
@@ -291,13 +291,13 @@ class AjaxUploader extends Component<UploadProps> {
     const events = disabled
       ? {}
       : {
-        onClick: openFileDialogOnClick ? this.onClick : () => { },
-        onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => { },
-        onMouseEnter,
-        onMouseLeave,
-        onDrop: this.onFileDrop,
-        onDragOver: this.onFileDrop,
-      };
+          onClick: openFileDialogOnClick ? this.onClick : () => { },
+          onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => { },
+          onMouseEnter,
+          onMouseLeave,
+          onDrop: this.onFileDrop,
+          onDragOver: this.onFileDrop,
+        };
     return (
       <Tag {...events} className={cls} role="button" style={style}>
         <input

--- a/tests/uploader.spec.js
+++ b/tests/uploader.spec.js
@@ -865,4 +865,9 @@ describe('uploader', () => {
     expect(wrapper.find('.bamboo-input').props().style.color).toEqual('red');
     expect(wrapper.find('input').props().style.display).toBe('none');
   });
+
+  it('the upload button wrapper span does not have the tabIndex attribute', () => {
+    const wrapper = mount(<Uploader />);
+    expect(wrapper.find('.rc-upload').props().tabIndex).toBe(undefined);
+  });
 });


### PR DESCRIPTION
When the upload button wrapper span has the tabIndex attribute, pressing the tab key will first focus on the span element, and then pressing tab again will focus on the button element.I removed span tabIndex attribute. issue link [45922](https://github.com/ant-design/ant-design/issues/45922)