### PR TITLE
feat: support paste upload file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ React.render(<Upload />, container);
 |customRequest | function | null | provide an override for the default xhr behavior for additional customization|
 |withCredentials | boolean | false | ajax upload with cookie send |
 |openFileDialogOnClick | boolean | true | useful for drag only upload as it does not trigger on enter key or click event |
-|allowPasteUpload | boolean | false | support paste upload |
+|pastable | boolean | false | support paste upload |
 
 #### onError arguments
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ React.render(<Upload />, container);
 |customRequest | function | null | provide an override for the default xhr behavior for additional customization|
 |withCredentials | boolean | false | ajax upload with cookie send |
 |openFileDialogOnClick | boolean | true | useful for drag only upload as it does not trigger on enter key or click event |
+|allowPasteUpload | boolean | false | support paste upload |
 
 #### onError arguments
 

--- a/docs/demo/paste.md
+++ b/docs/demo/paste.md
@@ -1,0 +1,8 @@
+---
+title: paste
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/paste.tsx"/></code>

--- a/docs/demo/pasteDirectory.md
+++ b/docs/demo/pasteDirectory.md
@@ -1,0 +1,8 @@
+---
+title: pasteDirectory
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/pasteDirectory.tsx"/></code>

--- a/docs/examples/paste.tsx
+++ b/docs/examples/paste.tsx
@@ -1,0 +1,43 @@
+/* eslint no-console:0 */
+import React from 'react';
+import Upload from 'rc-upload';
+
+const props = {
+  action: '/upload.do',
+  type: 'drag',
+  accept: '.png',
+  beforeUpload(file) {
+    console.log('beforeUpload', file.name);
+  },
+  onStart: file => {
+    console.log('onStart', file.name);
+  },
+  onSuccess(file) {
+    console.log('onSuccess', file);
+  },
+  onProgress(step, file) {
+    console.log('onProgress', Math.round(step.percent), file.name);
+  },
+  onError(err) {
+    console.log('onError', err);
+  },
+  style: { display: 'inline-block', width: 200, height: 200, background: '#eee' },
+};
+
+const Test = () => {
+  return (
+    <div
+      style={{
+        margin: 100,
+      }}
+    >
+      <div>
+        <Upload {...props}>
+          <a>开始上传</a>
+        </Upload>
+      </div>
+    </div>
+  );
+};
+
+export default Test;

--- a/docs/examples/paste.tsx
+++ b/docs/examples/paste.tsx
@@ -6,7 +6,7 @@ const props = {
   action: '/upload.do',
   type: 'drag',
   accept: '.png',
-  allowPasteUpload: true,
+  pastable: true,
   beforeUpload(file) {
     console.log('beforeUpload', file.name);
   },

--- a/docs/examples/paste.tsx
+++ b/docs/examples/paste.tsx
@@ -6,6 +6,7 @@ const props = {
   action: '/upload.do',
   type: 'drag',
   accept: '.png',
+  allowPasteUpload: true,
   beforeUpload(file) {
     console.log('beforeUpload', file.name);
   },

--- a/docs/examples/pasteDirectory.tsx
+++ b/docs/examples/pasteDirectory.tsx
@@ -7,6 +7,7 @@ const props = {
   type: 'drag',
   accept: '.png',
   directory: true,
+  allowPasteUpload: true,
   beforeUpload(file) {
     console.log('beforeUpload', file.name);
   },

--- a/docs/examples/pasteDirectory.tsx
+++ b/docs/examples/pasteDirectory.tsx
@@ -1,0 +1,44 @@
+/* eslint no-console:0 */
+import React from 'react';
+import Upload from 'rc-upload';
+
+const props = {
+  action: '/upload.do',
+  type: 'drag',
+  accept: '.png',
+  directory: true,
+  beforeUpload(file) {
+    console.log('beforeUpload', file.name);
+  },
+  onStart: file => {
+    console.log('onStart', file.name);
+  },
+  onSuccess(file) {
+    console.log('onSuccess', file);
+  },
+  onProgress(step, file) {
+    console.log('onProgress', Math.round(step.percent), file.name);
+  },
+  onError(err) {
+    console.log('onError', err);
+  },
+  style: { display: 'inline-block', width: 200, height: 200, background: '#eee' },
+};
+
+const Test = () => {
+  return (
+    <div
+      style={{
+        margin: 100,
+      }}
+    >
+      <div>
+        <Upload {...props}>
+          <a>开始上传</a>
+        </Upload>
+      </div>
+    </div>
+  );
+};
+
+export default Test;

--- a/docs/examples/pasteDirectory.tsx
+++ b/docs/examples/pasteDirectory.tsx
@@ -7,7 +7,7 @@ const props = {
   type: 'drag',
   accept: '.png',
   directory: true,
-  allowPasteUpload: true,
+  pastable: true,
   beforeUpload(file) {
     console.log('beforeUpload', file.name);
   },

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -28,8 +28,6 @@ class AjaxUploader extends Component<UploadProps> {
 
   private fileInput: HTMLInputElement;
 
-  private isMouseEnter: boolean;
-
   private _isMounted: boolean;
 
   onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -106,14 +104,21 @@ class AjaxUploader extends Component<UploadProps> {
   };
 
   onPrePaste(e: ClipboardEvent) {
-    if (this.isMouseEnter) {
+    const { allowPasteUpload } = this.props;
+
+    if (allowPasteUpload) {
       this.onFileDropOrPaste(e);
     }
   }
 
   componentDidMount() {
     this._isMounted = true;
-    document.addEventListener('paste', this.onPrePaste.bind(this));
+
+    const { allowPasteUpload } = this.props;
+
+    if (allowPasteUpload) {
+      document.addEventListener('paste', this.onPrePaste.bind(this));
+    }
   }
 
   componentWillUnmount() {
@@ -280,18 +285,6 @@ class AjaxUploader extends Component<UploadProps> {
     this.fileInput = node;
   };
 
-  handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
-    this.isMouseEnter = true;
-
-    this.props.onMouseEnter?.(e);
-  };
-
-  handleMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
-    this.isMouseEnter = false;
-
-    this.props.onMouseLeave?.(e);
-  };
-
   render() {
     const {
       component: Tag,
@@ -309,6 +302,8 @@ class AjaxUploader extends Component<UploadProps> {
       children,
       directory,
       openFileDialogOnClick,
+      onMouseEnter,
+      onMouseLeave,
       hasControlInside,
       ...otherProps
     } = this.props;
@@ -326,8 +321,8 @@ class AjaxUploader extends Component<UploadProps> {
       : {
           onClick: openFileDialogOnClick ? this.onClick : () => {},
           onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => {},
-          onMouseEnter: this.handleMouseEnter,
-          onMouseLeave: this.handleMouseLeave,
+          onMouseEnter,
+          onMouseLeave,
           onDrop: this.onFileDropOrPaste,
           onDragOver: this.onFileDropOrPaste,
           tabIndex: hasControlInside ? undefined : '0',

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -103,28 +103,38 @@ class AjaxUploader extends Component<UploadProps> {
     }
   };
 
-  onPrePaste(e: ClipboardEvent) {
-    const { allowPasteUpload } = this.props;
+  onPrePaste = (e: ClipboardEvent) => {
+    const { pastable } = this.props;
 
-    if (allowPasteUpload) {
+    if (pastable) {
       this.onFileDropOrPaste(e);
     }
-  }
+  };
 
   componentDidMount() {
     this._isMounted = true;
 
-    const { allowPasteUpload } = this.props;
+    const { pastable } = this.props;
 
-    if (allowPasteUpload) {
-      document.addEventListener('paste', this.onPrePaste.bind(this));
+    if (pastable) {
+      document.addEventListener('paste', this.onPrePaste);
     }
   }
 
   componentWillUnmount() {
     this._isMounted = false;
     this.abort();
-    document.removeEventListener('paste', this.onPrePaste.bind(this));
+    document.removeEventListener('paste', this.onPrePaste);
+  }
+
+  componentDidUpdate(prevProps: UploadProps) {
+    const { pastable } = this.props;
+
+    if (pastable && !prevProps.pastable) {
+      document.addEventListener('paste', this.onPrePaste);
+    } else if (!pastable && prevProps.pastable) {
+      document.removeEventListener('paste', this.onPrePaste);
+    }
   }
 
   uploadFiles = (files: File[]) => {

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -44,7 +44,7 @@ export interface UploadProps
     input?: React.CSSProperties;
   };
   hasControlInside?: boolean;
-  allowPasteUpload?: boolean;
+  pastable?: boolean;
 }
 
 export interface UploadProgressEvent extends Partial<ProgressEvent> {

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -44,6 +44,7 @@ export interface UploadProps
     input?: React.CSSProperties;
   };
   hasControlInside?: boolean;
+  allowPasteUpload?: boolean;
 }
 
 export interface UploadProgressEvent extends Partial<ProgressEvent> {

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -350,7 +350,7 @@ describe('uploader', () => {
     });
 
     it('paste to upload', done => {
-      const { container } = render(<Upload {...props} allowPasteUpload />);
+      const { container } = render(<Upload {...props} pastable />);
       const input = container.querySelector('input')!;
 
       const files = [
@@ -406,7 +406,7 @@ describe('uploader', () => {
     });
 
     it('paste files with multiple false', done => {
-      const { container } = render(<Upload {...props} multiple={false} allowPasteUpload />);
+      const { container } = render(<Upload {...props} multiple={false} pastable />);
       const input = container.querySelector('input')!;
       const files = [
         new File([''], 'success.png', { type: 'image/png' }),
@@ -780,7 +780,7 @@ describe('uploader', () => {
     });
 
     it('paste directory', done => {
-      const { container } = render(<Upload {...props} allowPasteUpload />);
+      const { container } = render(<Upload {...props} pastable />);
       const rcUpload = container.querySelector('.rc-upload')!;
       const files = {
         name: 'foo',

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -350,8 +350,8 @@ describe('uploader', () => {
     });
 
     it('paste to upload', done => {
-      const rcUpload = uploader.container.querySelector('.rc-upload')!;
-      const input = uploader.container.querySelector('input')!;
+      const { container } = render(<Upload {...props} allowPasteUpload />);
+      const input = container.querySelector('input')!;
 
       const files = [
         {
@@ -373,7 +373,6 @@ describe('uploader', () => {
         done(err);
       };
 
-      fireEvent.mouseEnter(rcUpload);
       fireEvent.paste(input, {
         clipboardData: { files },
       });
@@ -407,8 +406,7 @@ describe('uploader', () => {
     });
 
     it('paste files with multiple false', done => {
-      const { container } = render(<Upload {...props} multiple={false} />);
-      const rcUpload = container.querySelector('.rc-upload')!;
+      const { container } = render(<Upload {...props} multiple={false} allowPasteUpload />);
       const input = container.querySelector('input')!;
       const files = [
         new File([''], 'success.png', { type: 'image/png' }),
@@ -441,7 +439,6 @@ describe('uploader', () => {
         value: files,
       });
 
-      fireEvent.mouseEnter(rcUpload);
       fireEvent.paste(input, { clipboardData: { files } });
 
       setTimeout(() => {
@@ -783,7 +780,8 @@ describe('uploader', () => {
     });
 
     it('paste directory', done => {
-      const rcUpload = uploader.container.querySelector('.rc-upload')!;
+      const { container } = render(<Upload {...props} allowPasteUpload />);
+      const rcUpload = container.querySelector('.rc-upload')!;
       const files = {
         name: 'foo',
         children: [

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -349,7 +349,7 @@ describe('uploader', () => {
       }, 100);
     });
 
-    it('paste to upload', done => {
+    it('paste to upload', async () => {
       const { container } = render(<Upload {...props} pastable />);
       const input = container.querySelector('input')!;
 
@@ -366,23 +366,21 @@ describe('uploader', () => {
       handlers.onSuccess = (ret, file) => {
         expect(ret[1]).toEqual(file.name);
         expect(file).toHaveProperty('uid');
-        done();
       };
 
       handlers.onError = err => {
-        done(err);
+        throw err;
       };
 
       fireEvent.paste(input, {
         clipboardData: { files },
       });
 
-      setTimeout(() => {
-        requests[0].respond(200, {}, `["","${files[0].name}"]`);
-      }, 100);
+      await sleep(100);
+      requests[0].respond(200, {}, `["","${files[0].name}"]`);
     });
 
-    it('paste unaccepted type files to upload will not trigger onStart', done => {
+    it('paste unaccepted type files to upload will not trigger onStart', () => {
       const input = uploader.container.querySelector('input')!;
       const files = [
         {
@@ -399,13 +397,11 @@ describe('uploader', () => {
       });
       const mockStart = jest.fn();
       handlers.onStart = mockStart;
-      setTimeout(() => {
-        expect(mockStart.mock.calls.length).toBe(0);
-        done();
-      }, 100);
+
+      expect(mockStart.mock.calls.length).toBe(0);
     });
 
-    it('paste files with multiple false', done => {
+    it('paste files with multiple false', async () => {
       const { container } = render(<Upload {...props} multiple={false} pastable />);
       const input = container.querySelector('input')!;
       const files = [
@@ -422,28 +418,21 @@ describe('uploader', () => {
         triggerTimes += 1;
       };
       handlers.onSuccess = (ret, file) => {
-        try {
-          expect(ret[1]).toEqual(file.name);
-          expect(file).toHaveProperty('uid');
-          expect(triggerTimes).toEqual(1);
-          done();
-        } catch (error) {
-          done(error);
-        }
+        expect(ret[1]).toEqual(file.name);
+        expect(file).toHaveProperty('uid');
+        expect(triggerTimes).toEqual(1);
       };
       handlers.onError = error => {
-        done(error);
+        throw error;
       };
-
       Object.defineProperty(input, 'files', {
         value: files,
       });
 
       fireEvent.paste(input, { clipboardData: { files } });
 
-      setTimeout(() => {
-        handlers.onSuccess!(['', files[0].name] as any, files[0] as any, null!);
-      }, 100);
+      await sleep(100);
+      handlers.onSuccess!(['', files[0].name] as any, files[0] as any, null!);
     });
 
     it('support action and data is function returns Promise', async () => {
@@ -498,21 +487,6 @@ describe('uploader', () => {
       });
 
       fireEvent.change(input, { target: { files } });
-    });
-
-    it('support onMouseEnter and onMouseLeave', async () => {
-      const onMouseEnter = jest.fn();
-      const onMouseLeave = jest.fn();
-
-      const { container } = render(
-        <Upload onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />,
-      );
-      const rcUpload = container.querySelector('.rc-upload')!;
-
-      fireEvent.mouseEnter(rcUpload);
-      fireEvent.mouseLeave(rcUpload);
-      expect(onMouseEnter).toHaveBeenCalled();
-      expect(onMouseLeave).toHaveBeenCalled();
     });
   });
 
@@ -779,7 +753,7 @@ describe('uploader', () => {
       }, 100);
     });
 
-    it('paste directory', done => {
+    it('paste directory', async () => {
       const { container } = render(<Upload {...props} pastable />);
       const rcUpload = container.querySelector('.rc-upload')!;
       const files = {
@@ -796,10 +770,8 @@ describe('uploader', () => {
       const mockStart = jest.fn();
       handlers.onStart = mockStart;
 
-      setTimeout(() => {
-        expect(mockStart.mock.calls.length).toBe(1);
-        done();
-      }, 100);
+      await sleep(100);
+      expect(mockStart.mock.calls.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
ref: [ant-design/ant-design#46429](https://github.com/ant-design/ant-design/issues/46429)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 新增两个演示文档页面，展示文件上传示例和导航配置。

- **新功能**
  - 优化文件上传体验，新增支持拖拽和粘贴上传的交互方式。
  - 引入全新示例组件，直观演示文件上传操作及多文件处理行为。
  - API 文档中新增 `pastable` 属性，支持粘贴上传功能。

- **测试**
  - 增加多项测试用例，验证粘贴上传、多文件限制以及错误处理，确保上传功能的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->