### PR TITLE
fix: use type to deciding whether to allow drag

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -280,6 +280,7 @@ class AjaxUploader extends Component<UploadProps> {
       onMouseEnter,
       onMouseLeave,
       hasControlInside,
+      type,
       ...otherProps
     } = this.props;
     const cls = clsx({
@@ -298,8 +299,10 @@ class AjaxUploader extends Component<UploadProps> {
           onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => {},
           onMouseEnter,
           onMouseLeave,
-          onDrop: this.onFileDrop,
-          onDragOver: this.onFileDrop,
+          ...(type === 'drag' ? {
+            onDrop: this.onFileDrop,
+            onDragOver: this.onFileDrop,
+          } : {}),
           tabIndex: hasControlInside ? undefined : '0',
         };
     return (

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -211,7 +211,8 @@ describe('uploader', () => {
     });
 
     it('drag to upload', done => {
-      const input = uploader.container.querySelector('input')!;
+      const { container } = render(<Upload {...props} type='drag' />);
+      const input = container.querySelector('input')!;
 
       const files = [
         {
@@ -243,7 +244,8 @@ describe('uploader', () => {
     });
 
     it('drag unaccepted type files to upload will not trigger onStart', done => {
-      const input = uploader.container.querySelector('input')!;
+      const { container } = render(<Upload {...props} type='drag'/>);
+      const input = container.querySelector('input')!;
       const files = [
         {
           name: 'success.jpg',
@@ -266,7 +268,7 @@ describe('uploader', () => {
     });
 
     it('drag files with multiple false', done => {
-      const { container } = render(<Upload {...props} multiple={false} />);
+      const { container } = render(<Upload {...props} multiple={false} type='drag'/>);
       const input = container.querySelector('input')!;
       const files = [
         new File([''], 'success.png', { type: 'image/png' }),
@@ -400,7 +402,8 @@ describe('uploader', () => {
     });
 
     it('dragging and dropping a non file with a file does not prevent the file from being uploaded', done => {
-      const input = uploader.container.querySelector('input')!;
+      const { container } = render(<Upload {...props} type='drag' />);
+      const input = container.querySelector('input')!;
       const file = {
         name: 'success.png',
       };


### PR DESCRIPTION
Ref: https://github.com/ant-design/ant-design/issues/48300

antd use type to determine whether allow drag

> type == 'drag'

https://github.com/ant-design/ant-design/blob/a125dfee8bd3e78f93fc5ab0eb6d4ce8e6b1cd79/components/upload/Upload.tsx#L434

https://github.com/ant-design/ant-design/blob/a125dfee8bd3e78f93fc5ab0eb6d4ce8e6b1cd79/components/upload/Upload.tsx#L442-L447



> type != 'drag'

https://github.com/ant-design/ant-design/blob/a125dfee8bd3e78f93fc5ab0eb6d4ce8e6b1cd79/components/upload/Upload.tsx#L464-L466

https://github.com/ant-design/ant-design/blob/a125dfee8bd3e78f93fc5ab0eb6d4ce8e6b1cd79/components/upload/Upload.tsx#L476-L480


in Dragger also use type='drag'

https://github.com/ant-design/ant-design/blob/a125dfee8bd3e78f93fc5ab0eb6d4ce8e6b1cd79/components/upload/Dragger.tsx#L10-L14

