### PR TITLE
fix: Delay folder upload until all children files are parsed

### DIFF
--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -62,7 +62,6 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
             });
           }
           flattenFileList.push(file);
-          console.log(restDirectory);
           if (restDirectory === 0) {
             callback(flattenFileList);
           }

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -13,7 +13,7 @@ interface InternalDataTransferItem extends DataTransferItem {
 const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepted) => {
   let restFile = files.length;
   const flattenFileList = [];
-  function loopFiles(item: InternalDataTransferItem, callback) {
+  function loopFiles(item: InternalDataTransferItem, InnerCallback) {
     const dirReader = item.createReader();
     let fileList = [];
 
@@ -27,7 +27,7 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
 
         if (isFinished) {
           restFile = restFile - 1 + fileList.length;
-          callback(fileList);
+          InnerCallback(fileList);
         } else {
           sequence();
         }

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -11,7 +11,7 @@ interface InternalDataTransferItem extends DataTransferItem {
 }
 
 const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepted) => {
-  let restDirectory = 0;
+  let restFile = files.length;
   const flattenFileList = [];
   function loopFiles(item: InternalDataTransferItem, callback) {
     const dirReader = item.createReader();
@@ -26,7 +26,7 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
         const isFinished = !entryList.length;
 
         if (isFinished) {
-          restDirectory--;
+          restFile = restFile - 1 + fileList.length;
           callback(fileList);
         } else {
           sequence();
@@ -39,6 +39,7 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const _traverseFileTree = (item: InternalDataTransferItem, path?: string) => {
     if (!item) {
+      restFile = restFile - 1;
       return;
     }
     // eslint-disable-next-line no-param-reassign
@@ -62,13 +63,13 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
             });
           }
           flattenFileList.push(file);
-          if (restDirectory === 0) {
+          restFile = restFile - 1;
+          if (restFile === 0) {
             callback(flattenFileList);
           }
         }
       });
     } else if (item.isDirectory) {
-      restDirectory++;
       loopFiles(item, (entries: InternalDataTransferItem[]) => {
         entries.forEach(entryItem => {
           _traverseFileTree(entryItem, `${path}${item.name}/`);

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -25,7 +25,7 @@ const makeFileSystemEntry = item => {
       return {
         readEntries(handle) {
           if (!first) {
-            return [];
+            return handle([]);
           }
 
           first = false;
@@ -374,6 +374,56 @@ describe('uploader', () => {
       uploader = render(<Upload {...props} />);
     });
 
+    it('beforeUpload should run after all children files are parsed', done => {
+      const props = { action: '/test', directory: true, accept: '.png' };
+      const mockBeforeUpload = jest.fn();
+      const beforeUpload = (file, fileList) => {
+        console.log('beforeUpload', file, fileList);
+        mockBeforeUpload(file, fileList);
+      };
+      const Test = () => {
+        return <Upload {...props} beforeUpload={beforeUpload} />;
+      };
+
+      const { container } = render(<Test />);
+      const files = {
+        name: 'foo',
+        children: [
+          {
+            name: 'bar',
+            children: [
+              {
+                name: '1.png',
+              },
+              {
+                name: '2.png',
+              },
+              {
+                name: 'rc',
+                children: [
+                  {
+                    name: '3.png',
+                  },
+                  {
+                    name: '4.png',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const input = container.querySelector('input')!;
+      fireEvent.drop(input, { dataTransfer: { items: [makeDataTransferItem(files)] } });
+      setTimeout(() => {
+        expect(mockBeforeUpload.mock.calls.length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[0][1].length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[1][1].length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[2][1].length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[3][1].length).toBe(4);
+        done();
+      }, 100);
+    });
     it('unaccepted type files to upload will not trigger onStart', done => {
       const input = uploader.container.querySelector('input')!;
       const files = {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[antd issue](https://github.com/ant-design/ant-design/issues/49252)


### 💡 需求背景和解决方案
当拖拽上传文件夹时，需要手动解析文件树，原代码在解析到子文件为非文件夹时直接执行后续而非等待全部文件解析完成，与普通上传的表现不一致。添加其他变量确保文件全部解析后再进行后续操作
