### PR TITLE
demo: 添加dragDirectory拖拽上传文件夹demo

### DIFF
--- a/docs/demo/dragDirectory.md
+++ b/docs/demo/dragDirectory.md
@@ -1,0 +1,8 @@
+---
+title: dragDirectory
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/dragDirectory.tsx"/></code>

--- a/docs/examples/dragDirectory.tsx
+++ b/docs/examples/dragDirectory.tsx
@@ -1,0 +1,44 @@
+/* eslint no-console:0 */
+import React from 'react';
+import Upload from 'rc-upload';
+
+const props = {
+  action: '/upload.do',
+  type: 'drag',
+  directory: true,
+  beforeUpload(file, fileList) {
+    console.log('beforeUpload', file.name, fileList);
+  },
+  onStart: file => {
+    console.log('onStart', file.name);
+  },
+  onSuccess(file) {
+    console.log('onSuccess', file);
+  },
+  onProgress(step, file) {
+    console.log('onProgress', Math.round(step.percent), file.name);
+  },
+  onError(err) {
+    console.log('onError', err);
+  },
+  style: { display: 'inline-block', width: 200, height: 200, background: '#eee' },
+  // openFileDialogOnClick: false
+};
+
+const Test = () => {
+  return (
+    <div
+      style={{
+        margin: 100,
+      }}
+    >
+      <div>
+        <Upload {...props}>
+          <a>开始上传</a>
+        </Upload>
+      </div>
+    </div>
+  );
+};
+
+export default Test;


### PR DESCRIPTION
目前upload组件demo中缺少拖拽上传文件夹示例，添加dragDirectory拖拽上传文件夹demo，方便查看拖拽上传文件夹交互及beforeUpload回调参数；