### PR TITLE
fix:delay folder upload until all children files are parsed when drag

### DIFF
--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -20,25 +20,19 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
     let fileList = [];
 
     function sequence() {
-      dirReader.readEntries(
-        (entries: InternalDataTransferItem[]) => {
-          const entryList = Array.prototype.slice.apply(entries);
-          fileList = fileList.concat(entryList);
+      dirReader.readEntries((entries: InternalDataTransferItem[]) => {
+        const entryList = Array.prototype.slice.apply(entries);
+        fileList.push(...entryList);
 
-          // Check if all the file has been viewed
-          const isFinished = !entryList.length;
+        // Check if all the file has been viewed
+        const isFinished = !entryList.length;
 
-          if (isFinished) {
-            wipIndex++;
-            progressFileList = progressFileList.concat(fileList);
-          } else {
-            sequence();
-          }
-        },
-        () => {
-          wipIndex++;
-        },
-      );
+        if (isFinished) {
+          progressFileList = progressFileList.concat(fileList);
+        } else {
+          sequence();
+        }
+      });
     }
 
     sequence();
@@ -46,7 +40,6 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const _traverseFileTree = (item: InternalDataTransferItem, path?: string) => {
     if (!item) {
-      wipIndex++;
       return;
     }
     // eslint-disable-next-line no-param-reassign
@@ -72,7 +65,6 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
           flattenFileList.push(file);
         }
       });
-      wipIndex++;
     } else if (item.isDirectory) {
       loopFiles(item);
     }
@@ -81,10 +73,9 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
   function walkFiles() {
     while (wipIndex < progressFileList.length) {
       _traverseFileTree(progressFileList[wipIndex]);
-      if (wipIndex === progressFileList.length) {
-        callback(flattenFileList);
-      }
+      wipIndex++;
     }
+    callback(flattenFileList);
   }
   walkFiles();
 };

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -12,7 +12,7 @@ interface InternalDataTransferItem extends DataTransferItem {
 
 const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepted) => {
   const flattenFileList = [];
-  let progressFileList = [];
+  const progressFileList = [];
   files.forEach(file => progressFileList.push(file.webkitGetAsEntry() as any));
   function loopFiles(item: InternalDataTransferItem) {
     const dirReader = item.createReader();

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -20,20 +20,25 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
     let fileList = [];
 
     function sequence() {
-      dirReader.readEntries((entries: InternalDataTransferItem[]) => {
-        const entryList = Array.prototype.slice.apply(entries);
-        fileList = fileList.concat(entryList);
+      dirReader.readEntries(
+        (entries: InternalDataTransferItem[]) => {
+          const entryList = Array.prototype.slice.apply(entries);
+          fileList = fileList.concat(entryList);
 
-        // Check if all the file has been viewed
-        const isFinished = !entryList.length;
+          // Check if all the file has been viewed
+          const isFinished = !entryList.length;
 
-        if (isFinished) {
+          if (isFinished) {
+            wipIndex++;
+            progressFileList = progressFileList.concat(fileList);
+          } else {
+            sequence();
+          }
+        },
+        () => {
           wipIndex++;
-          progressFileList = progressFileList.concat(fileList);
-        } else {
-          sequence();
-        }
-      });
+        },
+      );
     }
 
     sequence();

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -67,6 +67,11 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
           if (restFile === 0) {
             callback(flattenFileList);
           }
+        } else {
+          restFile = restFile - 1;
+          if (restFile === 0) {
+            callback(flattenFileList);
+          }
         }
       });
     } else if (item.isDirectory) {

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -24,9 +24,7 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
         progressFileList.push(...entryList);
         // Check if all the file has been viewed
         const isFinished = !entryList.length;
-        if (isFinished) {
-          return;
-        } else {
+        if (!isFinished) {
           sequence();
         }
       });

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -13,22 +13,19 @@ interface InternalDataTransferItem extends DataTransferItem {
 const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepted) => {
   const flattenFileList = [];
   let progressFileList = [];
-  let wipIndex = 0;
   files.forEach(file => progressFileList.push(file.webkitGetAsEntry() as any));
   function loopFiles(item: InternalDataTransferItem) {
     const dirReader = item.createReader();
-    let fileList = [];
 
     function sequence() {
       dirReader.readEntries((entries: InternalDataTransferItem[]) => {
         const entryList = Array.prototype.slice.apply(entries);
-        fileList.push(...entryList);
 
+        progressFileList.push(...entryList);
         // Check if all the file has been viewed
         const isFinished = !entryList.length;
-
         if (isFinished) {
-          progressFileList = progressFileList.concat(fileList);
+          return;
         } else {
           sequence();
         }
@@ -71,6 +68,7 @@ const traverseFileTree = (files: InternalDataTransferItem[], callback, isAccepte
   };
 
   function walkFiles() {
+    let wipIndex = 0;
     while (wipIndex < progressFileList.length) {
       _traverseFileTree(progressFileList[wipIndex]);
       wipIndex++;

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -25,7 +25,7 @@ const makeFileSystemEntry = item => {
       return {
         readEntries(handle) {
           if (!first) {
-            return [];
+            return handle([]);
           }
 
           first = false;
@@ -373,7 +373,56 @@ describe('uploader', () => {
     beforeEach(() => {
       uploader = render(<Upload {...props} />);
     });
+    it('beforeUpload should run after all children files are parsed', done => {
+      const props = { action: '/test', directory: true, accept: '.png' };
+      const mockBeforeUpload = jest.fn();
+      const beforeUpload = (file, fileList) => {
+        console.log('beforeUpload', file, fileList);
+        mockBeforeUpload(file, fileList);
+      };
+      const Test = () => {
+        return <Upload {...props} beforeUpload={beforeUpload} />;
+      };
 
+      const { container } = render(<Test />);
+      const files = {
+        name: 'foo',
+        children: [
+          {
+            name: 'bar',
+            children: [
+              {
+                name: '1.png',
+              },
+              {
+                name: '2.png',
+              },
+              {
+                name: 'rc',
+                children: [
+                  {
+                    name: '3.png',
+                  },
+                  {
+                    name: '4.png',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const input = container.querySelector('input')!;
+      fireEvent.drop(input, { dataTransfer: { items: [makeDataTransferItem(files)] } });
+      setTimeout(() => {
+        expect(mockBeforeUpload.mock.calls.length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[0][1].length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[1][1].length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[2][1].length).toBe(4);
+        expect(mockBeforeUpload.mock.calls[3][1].length).toBe(4);
+        done();
+      }, 100);
+    });
     it('unaccepted type files to upload will not trigger onStart', done => {
       const input = uploader.container.querySelector('input')!;
       const files = {

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -401,10 +401,10 @@ describe('uploader', () => {
                 name: 'rc',
                 children: [
                   {
-                    name: '3.png',
+                    name: '5.webp',
                   },
                   {
-                    name: '4.png',
+                    name: '4.webp',
                   },
                 ],
               },
@@ -415,11 +415,9 @@ describe('uploader', () => {
       const input = container.querySelector('input')!;
       fireEvent.drop(input, { dataTransfer: { items: [makeDataTransferItem(files)] } });
       setTimeout(() => {
-        expect(mockBeforeUpload.mock.calls.length).toBe(4);
-        expect(mockBeforeUpload.mock.calls[0][1].length).toBe(4);
-        expect(mockBeforeUpload.mock.calls[1][1].length).toBe(4);
-        expect(mockBeforeUpload.mock.calls[2][1].length).toBe(4);
-        expect(mockBeforeUpload.mock.calls[3][1].length).toBe(4);
+        expect(mockBeforeUpload.mock.calls.length).toBe(2);
+        expect(mockBeforeUpload.mock.calls[0][1].length).toBe(2);
+        expect(mockBeforeUpload.mock.calls[1][1].length).toBe(2);
         done();
       }, 100);
     });


### PR DESCRIPTION
🔗 相关 Issue
https://github.com/ant-design/ant-design/issues/49252
https://github.com/react-component/upload/issues/453
ps:之前提过[pr](https://github.com/react-component/upload/pull/559)，但是commit记录太乱了,大佬后面也没看就重新开了一个

💡 需求背景和解决方案
当拖拽上传文件夹时，需要手动解析文件树，原代码在解析到子文件为非文件夹时直接执行后续而非等待全部文件解析完成，与普通上传的表现不一致。添加其他变量确保文件全部解析后再进行后续操作
主要改动的地方:
1.traverseFileTree.ts中添加restFile变量记录剩余文件数量，将原本的loopFiles函数移动到了traverseFileTree里便于访问restFile变量
2.原测试中工具函数makeFileSystemEntry逻辑错误，导致当上传的文件夹包含子文件夹时无法进入开始上传逻辑，在测试 https://github.com/react-component/upload/blob/master/tests/uploader.spec.tsx#L377 将webp后缀改成png后测试任然通过可以验证这个bug
![c5a1dab39e5f2a6a8c0800e6ddb5d5ac](https://github.com/react-component/upload/assets/116932167/72c87cf1-b7e0-4ad9-90e6-deac1e48d49d)
3.添加了相关测试