### PR TITLE
fix: upload drag directory can not work

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -66,7 +66,7 @@ class AjaxUploader extends Component<UploadProps> {
     }
   };
 
-  onFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
+  onFileDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     const { multiple } = this.props;
 
     e.preventDefault();
@@ -76,11 +76,11 @@ class AjaxUploader extends Component<UploadProps> {
     }
 
     if (this.props.directory) {
-      traverseFileTree(
+      const files = await traverseFileTree(
         Array.prototype.slice.call(e.dataTransfer.items),
-        this.uploadFiles,
         (_file: RcFile) => attrAccept(_file, this.props.accept),
       );
+      this.uploadFiles(files);
     } else {
       let files = [...e.dataTransfer.files].filter((file: RcFile) =>
         attrAccept(file, this.props.accept),

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -21,8 +21,8 @@ const traverseFileTree = async (files: InternalDataTransferItem[], isAccepted) =
     const entries = [];
 
     while (true) {
-      const results = await new Promise<InternalDataTransferItem[]>((resolve, reject) => {
-        dirReader.readEntries(resolve, reject);
+      const results = await new Promise<InternalDataTransferItem[]>((resolve) => {
+        dirReader.readEntries(resolve, () => resolve([]));
       });
 
       if (!results.length) {

--- a/src/traverseFileTree.ts
+++ b/src/traverseFileTree.ts
@@ -24,13 +24,14 @@ const traverseFileTree = async (files: InternalDataTransferItem[], isAccepted) =
       const results = await new Promise<InternalDataTransferItem[]>((resolve) => {
         dirReader.readEntries(resolve, () => resolve([]));
       });
-
-      if (!results.length) {
+      const n = results.length;
+      
+      if (!n) {
         break;
       }
 
-      for (const entry of results) {
-        entries.push(entry);
+      for (let i = 0; i < n; i++) {
+        entries.push(results[i]);
       }
     }
     return entries;


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/50080
https://github.com/react-component/upload/blob/80e5228ffd58114974b7eb98d6f93d8a6213bb7c/src/traverseFileTree.ts#L20-L31

出现这个bug的原因大概率是因为异步api导致，`dirReader.readEntries`是异步且被递归调用，`walkFiles`这个方法又是同步执行的，while循环结束了一会之后才会走入`readEntries`的回调，导致`callback`其实是提前拿了一个空数组就提前结束。