### PR TITLE
feat: support `name` prop

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -269,6 +269,7 @@ class AjaxUploader extends Component<UploadProps> {
       classNames = {},
       disabled,
       id,
+      name,
       style,
       styles = {},
       multiple,
@@ -307,6 +308,7 @@ class AjaxUploader extends Component<UploadProps> {
         <input
           {...pickAttrs(otherProps, { aria: true, data: true })}
           id={id}
+          name={name}
           disabled={disabled}
           type="file"
           ref={this.saveFileInput}

--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -11,7 +11,6 @@ class Upload extends Component<UploadProps> {
     prefixCls: 'rc-upload',
     data: {},
     headers: {},
-    name: 'file',
     multipart: false,
     onStart: empty,
     onError: empty,

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -152,6 +152,12 @@ describe('uploader', () => {
       expect(container.querySelector('input')!.id).toBe('bamboo');
     });
 
+    // https://github.com/ant-design/ant-design/issues/50643
+    it('with name', () => {
+      const { container } = render(<Upload name="bamboo" />);
+      expect(container.querySelector('input')!.name).toBe('bamboo');
+    });
+
     it('should pass through data & aria attributes', () => {
       const { container } = render(
         <Upload


### PR DESCRIPTION
background: https://github.com/ant-design/ant-design/issues/50643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `AjaxUploader` 组件中添加了 `name` 属性，以增强文件输入的可识别性和表单提交的功能。
- **变更**
	- 移除 `Upload` 组件中的 `name` 属性的默认状态初始化，提升了文件上传的灵活性。
- **测试**
	- 在 `uploader` 测试套件中新增测试用例，验证 `Upload` 组件是否正确处理 `name` 属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->