### PR TITLE
fix: when the upload setting pastable is set to true in the same Form, the copying of FormItemInput becomes invalid

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -85,7 +85,7 @@ class AjaxUploader extends Component<UploadProps> {
       files = [...(clipboardData.files || [])];
     }
 
-    if (items.some(item => item.kind === 'file') || files.length > 0) {
+    if (files.length > 0 || items.some(item => item.kind === 'file')) {
       e.preventDefault();
     }
 

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -67,8 +67,6 @@ class AjaxUploader extends Component<UploadProps> {
   };
 
   onFileDropOrPaste = async (e: React.DragEvent<HTMLDivElement> | ClipboardEvent) => {
-    e.preventDefault();
-
     if (e.type === 'dragover') {
       return;
     }
@@ -76,15 +74,22 @@ class AjaxUploader extends Component<UploadProps> {
     const { multiple, accept, directory } = this.props;
     let items: DataTransferItem[] = [];
     let files: File[] = [];
+    let hasFile: boolean = false;
 
     if (e.type === 'drop') {
       const dataTransfer = (e as React.DragEvent<HTMLDivElement>).dataTransfer;
       items = [...(dataTransfer.items || [])];
       files = [...(dataTransfer.files || [])];
+      hasFile = items.some(item => item.kind === 'file');
     } else if (e.type === 'paste') {
       const clipboardData = (e as ClipboardEvent).clipboardData;
       items = [...(clipboardData.items || [])];
       files = [...(clipboardData.files || [])];
+      hasFile = items.some(item => item.kind === 'file') || files.length > 0;
+    }
+
+    if (hasFile) {
+      e.preventDefault();
     }
 
     if (directory) {

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -74,21 +74,18 @@ class AjaxUploader extends Component<UploadProps> {
     const { multiple, accept, directory } = this.props;
     let items: DataTransferItem[] = [];
     let files: File[] = [];
-    let hasFile: boolean = false;
 
     if (e.type === 'drop') {
       const dataTransfer = (e as React.DragEvent<HTMLDivElement>).dataTransfer;
       items = [...(dataTransfer.items || [])];
       files = [...(dataTransfer.files || [])];
-      hasFile = items.some(item => item.kind === 'file');
     } else if (e.type === 'paste') {
       const clipboardData = (e as ClipboardEvent).clipboardData;
       items = [...(clipboardData.items || [])];
       files = [...(clipboardData.files || [])];
-      hasFile = items.some(item => item.kind === 'file') || files.length > 0;
     }
 
-    if (hasFile) {
+    if (items.some(item => item.kind === 'file') || files.length > 0) {
       e.preventDefault();
     }
 

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -488,6 +488,42 @@ describe('uploader', () => {
 
       fireEvent.change(input, { target: { files } });
     });
+
+    it('should call preventDefault when paste contains files', () => {
+      const { container } = render(<Upload {...props} pastable />);
+      const input = container.querySelector('input')!;
+
+      const files = [new File([''], 'test.png', { type: 'image/png' })];
+
+      const preventDefaultSpy = jest.spyOn(Event.prototype, 'preventDefault');
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          items: [{ kind: 'file' }],
+          files,
+        },
+      });
+
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+      preventDefaultSpy.mockRestore();
+    });
+
+    it('should not call preventDefault when paste contains no files', () => {
+      const { container } = render(<Upload {...props} pastable />);
+      const input = container.querySelector('input')!;
+
+      const preventDefaultSpy = jest.spyOn(Event.prototype, 'preventDefault');
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          items: [{ kind: 'string' }],
+          files: [],
+        },
+      });
+
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(0);
+      preventDefaultSpy.mockRestore();
+    });
   });
 
   describe('directory uploader', () => {


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/53907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化了拖拽或粘贴文件时的事件处理逻辑，仅在检测到实际文件时才阻止默认行为，避免对非文件拖拽或粘贴操作产生影响。
  - 新增粘贴事件处理的测试用例，确保只有包含文件的粘贴事件会阻止默认行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->