### PR TITLE
fix: Upload drag & drop not working

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -66,11 +66,15 @@ class AjaxUploader extends Component<UploadProps> {
     }
   };
 
-  onDataTransferFiles = async (dataTransfer: DataTransfer) => {
+  onDataTransferFiles = async (dataTransfer: DataTransfer, existFileCallback?: () => void) => {
     const { multiple, accept, directory } = this.props;
 
     const items: DataTransferItem[] = [...(dataTransfer.items || [])];
     let files: File[] = [...(dataTransfer.files || [])];
+
+    if (files.length > 0 || items.some(item => item.kind === 'file')) {
+      existFileCallback?.();
+    }
 
     if (directory) {
       files = await traverseFileTree(Array.prototype.slice.call(items), (_file: RcFile) =>
@@ -97,7 +101,9 @@ class AjaxUploader extends Component<UploadProps> {
 
     if (e.type === 'paste') {
       const clipboardData = (e as ClipboardEvent).clipboardData;
-      return this.onDataTransferFiles(clipboardData);
+      return this.onDataTransferFiles(clipboardData, () => {
+        e.preventDefault();
+      });
     }
   };
 

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -735,6 +735,12 @@ describe('uploader', () => {
           },
         ],
       };
+
+      const preventDefaultSpy = jest.spyOn(Event.prototype, 'preventDefault');
+
+      fireEvent.dragOver(input);
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+
       fireEvent.drop(input, { dataTransfer: { items: [makeDataTransferItemAsync(files)] } });
       const mockStart = jest.fn();
       handlers.onStart = mockStart;
@@ -743,6 +749,8 @@ describe('uploader', () => {
         expect(mockStart.mock.calls.length).toBe(1);
         done();
       }, 1000);
+
+      preventDefaultSpy.mockRestore();
     });
 
     it('unaccepted type files to upload will not trigger onStart when select directory', done => {


### PR DESCRIPTION
### 故障原因

在 #624 中，对存在文件的情况进行 `preventDefault` 处理。这本对于 Paste 和 Drog 都会有效，但是由于原来的 `onFileDropOrPaste` 方法其实除了处理 `paste` 和 `drop` 事件外，还处理了 `onDragOver` 事件。而 `onDragOver` 事件是没有 files 要处理的，导致其不会触发 `preventDefault` 逻辑。

当文件拖拽不处理 `dragOver` 的 `preventDefault` 时，`drop` 也会被浏览器忽略。

此外，测试用例中也仅仅做了 `drop` 事件的测试，而没有做 `dragOver` 测试导致 `preventDefault` 逃逸。

### 修复方式

重构了这部分代码，将三个事件拆分成独立的函数进行分别处理。对于相同逻辑处，提取 `onDataTransferFiles` 抽象逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了文件拖拽和粘贴上传的事件处理逻辑，提升了代码可读性和维护性。
- **测试**
  - 增强了拖拽上传目录的测试用例，确保在拖拽经过时会正确阻止浏览器默认行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->