### PR TITLE
修复拖拽不符合要求的文件，仍然调用beforeUpload

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -85,7 +85,7 @@ class AjaxUploader extends Component<UploadProps> {
       let acceptFiles = [...files].filter((file: RcFile) => attrAccept(file, accept));
 
       if (multiple === false) {
-        acceptFiles = files.slice(0, 1);
+        acceptFiles = acceptFiles.slice(0, 1);
       }
 
       this.uploadFiles(acceptFiles);

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -307,7 +307,32 @@ describe('uploader', () => {
         done();
       }, 100);
     });
+    
+   it('drag unaccepted type files with multiple false to upload will not trigger onStart ', done => {
+      const { container } = render(<Upload {...props} multiple={false} />);
 
+      const input = container.querySelector('input')!;
+      const files = [
+        {
+          name: 'success.jpg',
+          toString() {
+            return this.name;
+          },
+        },
+      ];
+      (files as any).item = (i: number) => files[i];
+
+      fireEvent.drop(input, {
+        dataTransfer: { files },
+      });
+      const mockStart = jest.fn();
+      handlers.onStart = mockStart;
+      setTimeout(() => {
+        expect(mockStart.mock.calls.length).toBe(0);
+        done();
+      }, 100);
+    });
+    
     it('drag files with multiple false', done => {
       const { container } = render(<Upload {...props} multiple={false} />);
       const input = container.querySelector('input')!;

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -322,11 +322,11 @@ describe('uploader', () => {
       ];
       (files as any).item = (i: number) => files[i];
 
+      const mockStart = jest.fn();
+      handlers.onStart = mockStart;
       fireEvent.drop(input, {
         dataTransfer: { files },
       });
-      const mockStart = jest.fn();
-      handlers.onStart = mockStart;
       setTimeout(() => {
         expect(mockStart.mock.calls.length).toBe(0);
         done();


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **修复问题**
  - 修正了上传文件时的筛选逻辑，确保在仅允许单文件上传时，只会上传通过类型校验的第一个文件。
  - 增加了拖拽上传时对不接受文件类型的处理测试，确保不会触发上传开始回调。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

close https://github.com/ant-design/ant-design/issues/36318