### PR TITLE
fix(uploader): openFileDialogOnClick支持传入函数

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ React.render(<Upload />, container);
 |beforeUpload| function |null| before upload check, return false or a rejected Promise will stop upload, only for modern browsers|
 |customRequest | function | null | provide an override for the default xhr behavior for additional customization|
 |withCredentials | boolean | false | ajax upload with cookie send |
-|openFileDialogOnClick | boolean | true | useful for drag only upload as it does not trigger on enter key or click event |
+|openFileDialogOnClick | boolean/function():boolean | true | useful for drag only upload as it does not trigger on enter key or click event |
 
 #### onError arguments
 

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -261,6 +261,11 @@ class AjaxUploader extends Component<UploadProps> {
     this.fileInput = node;
   };
 
+  eventHandler = (fn: (() => boolean) | boolean, originFn: Function, e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
+    if (typeof fn === 'function' ? fn() : fn) {
+      originFn(e);
+    }
+  };
   render() {
     const {
       component: Tag,
@@ -294,8 +299,8 @@ class AjaxUploader extends Component<UploadProps> {
     const events = disabled
       ? {}
       : {
-          onClick: openFileDialogOnClick ? this.onClick : () => {},
-          onKeyDown: openFileDialogOnClick ? this.onKeyDown : () => {},
+          onClick: (e) => this.eventHandler(openFileDialogOnClick, this.onClick, e),
+          onKeyDown: (e) => this.eventHandler(openFileDialogOnClick, this.onKeyDown, e),
           onMouseEnter,
           onMouseLeave,
           onDrop: this.onFileDrop,

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -305,7 +305,7 @@ class AjaxUploader extends Component<UploadProps> {
     this.fileInput = node;
   };
 
-  eventHandler = (fn: (() => boolean) | boolean, originFn: Function, e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
+  eventHandler = (fn: (() => boolean) | boolean, originFn: (e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void, e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
     if (typeof fn === 'function' ? fn() : fn) {
       originFn(e);
     }

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -31,7 +31,7 @@ export interface UploadProps
   ) => BeforeUploadFileType | Promise<void | BeforeUploadFileType> | void;
   customRequest?: (option: UploadRequestOption) => void | { abort: () => void };
   withCredentials?: boolean;
-  openFileDialogOnClick?: boolean;
+  openFileDialogOnClick?: boolean | (() => boolean);
   prefixCls?: string;
   id?: string;
   onMouseEnter?: (e: React.MouseEvent<HTMLDivElement>) => void;

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -1187,6 +1187,53 @@ describe('uploader', () => {
     });
   });
 
+  describe('openFileDialogOnClick', () => {
+    it('should block click when set to false', () => {
+      const onClick = jest.fn();
+      const { container } = render(<Upload openFileDialogOnClick={false} onClick={onClick} />);
+      fireEvent.click(container.querySelector('.rc-upload')!);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('should allow click when set to true', () => {
+      const onClick = jest.fn();
+      const { container } = render(<Upload openFileDialogOnClick={true} onClick={onClick} />);
+      fireEvent.click(container.querySelector('.rc-upload')!);
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    it('should block click when function returns false', () => {
+      const onClick = jest.fn();
+      const { container } = render(<Upload openFileDialogOnClick={() => false} onClick={onClick} />);
+      fireEvent.click(container.querySelector('.rc-upload')!);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('should allow click when function returns true', () => {
+      const onClick = jest.fn();
+      const { container } = render(<Upload openFileDialogOnClick={() => true} onClick={onClick} />);      
+      fireEvent.click(container.querySelector('.rc-upload')!);
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    it('should support dynamic function return value', () => {
+      let shouldOpen = false;
+      const onClick = jest.fn();
+      const { container, rerender } = render(<Upload openFileDialogOnClick={() => shouldOpen} onClick={onClick} />);
+      
+      // first click (shouldOpen = false)
+      fireEvent.click(container.querySelector('.rc-upload')!);
+      expect(onClick).not.toHaveBeenCalled();
+
+      shouldOpen = true;
+      rerender(<Upload openFileDialogOnClick={() => shouldOpen} onClick={onClick} />);
+
+      // second click (shouldOpen = true)
+      fireEvent.click(container.querySelector('.rc-upload')!);
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+
   it('dynamic change action in beforeUpload should work', async () => {
     const Test = () => {
       const [action, setAction] = React.useState('light');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - `openFileDialogOnClick` 属性现支持传入布尔值或返回布尔值的函数，提升了文件对话框打开行为的灵活性。

- **文档**
  - 更新了 API 文档，反映 `openFileDialogOnClick` 属性类型的变化。

- **测试**
  - 新增针对 `openFileDialogOnClick` 属性不同用法的测试用例，确保其行为符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->