### PR TITLE
feat: support folder and deprecated directory

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -1,7 +1,6 @@
 /* eslint react/no-is-mounted:0,react/sort-comp:0,react/prop-types:0 */
 import clsx from 'classnames';
 import pickAttrs from 'rc-util/lib/pickAttrs';
-import warning from 'rc-util/lib/warning';
 import React, { Component } from 'react';
 import attrAccept from './attr-accept';
 import type {
@@ -329,11 +328,6 @@ class AjaxUploader extends Component<UploadProps> {
       hasControlInside,
       ...otherProps
     } = this.props;
-
-    warning(
-      !('directory' in this.props),
-      'directory will be deprecated, please use folder. folder will not filter files other than accept, just like the native method.',
-    );
     const cls = clsx({
       [prefixCls]: true,
       [`${prefixCls}-disabled`]: disabled,

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -1,6 +1,7 @@
 /* eslint react/no-is-mounted:0,react/sort-comp:0,react/prop-types:0 */
 import clsx from 'classnames';
 import pickAttrs from 'rc-util/lib/pickAttrs';
+import warning from 'rc-util/lib/warning';
 import React, { Component } from 'react';
 import attrAccept from './attr-accept';
 import type {
@@ -321,21 +322,26 @@ class AjaxUploader extends Component<UploadProps> {
       capture,
       children,
       directory,
+      folder,
       openFileDialogOnClick,
       onMouseEnter,
       onMouseLeave,
       hasControlInside,
       ...otherProps
     } = this.props;
+
+    warning(
+      !('directory' in this.props),
+      'directory will be deprecated, please use folder. folder will not filter files other than accept, just like the native method.',
+    );
     const cls = clsx({
       [prefixCls]: true,
       [`${prefixCls}-disabled`]: disabled,
       [className]: className,
     });
     // because input don't have directory/webkitdirectory type declaration
-    const dirProps: any = directory
-      ? { directory: 'directory', webkitdirectory: 'webkitdirectory' }
-      : {};
+    const dirProps: any =
+      directory || folder ? { directory: 'directory', webkitdirectory: 'webkitdirectory' } : {};
     const events = disabled
       ? {}
       : {

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -13,7 +13,9 @@ export interface UploadProps
   component?: React.ComponentType<any> | string;
   action?: Action;
   method?: UploadRequestMethod;
+  /** @deprecated Please use `folder` instead */
   directory?: boolean;
+  folder?: boolean;
   data?: Record<string, unknown> | ((file: RcFile | string | Blob) => Record<string, unknown>);
   headers?: UploadRequestHeader;
   accept?: string;

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -1038,6 +1038,18 @@ describe('uploader', () => {
         directory: false,
       },
     );
+
+    it('should trigger beforeUpload when uploading non-accepted files in folder mode', () => {
+      const beforeUpload = jest.fn();
+      const { container } = render(<Upload accept=".png" folder beforeUpload={beforeUpload} />);
+
+      fireEvent.change(container.querySelector('input')!, {
+        target: {
+          files: [new File([], 'bamboo.png'), new File([], 'light.jpg')],
+        },
+      });
+      expect(beforeUpload).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('transform file before request', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 `folder` 属性以支持文件夹上传，行为与原生一致。

* **文档**
  * 标记 `directory` 属性为已废弃，并建议改用 `folder` 属性。使用 `directory` 时会显示弃用警告。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->