### PR TITLE
feat: Support non-click folder upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ React.render(<Upload />, container);
 |component | "div"|"span" | "span"| wrap component name |
 |action| string &#124; function(file): string &#124; Promise&lt;string&gt; | | form action url |
 |method | string | post | request method |
-|directory| boolean | false | support upload whole directory |
+|directory| boolean \| 'nonClick' | false | support upload whole directory, 'nonClick' means unSupport click to upload directory |
 |data| object/function(file) | | other data object to post or a function which returns a data object(a promise object which resolve a data object) |
 |headers| object | {} | http headers to post, available in modern browsers |
 |accept | string | | input accept attribute |

--- a/docs/demo/dragOnlyDirectory.md
+++ b/docs/demo/dragOnlyDirectory.md
@@ -1,0 +1,9 @@
+---
+title: dragOnlyDirectory
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/dragOnlyDirectory.tsx"></code>
+

--- a/docs/examples/dragOnlyDirectory.tsx
+++ b/docs/examples/dragOnlyDirectory.tsx
@@ -1,0 +1,44 @@
+/* eslint no-console:0 */
+import React from 'react';
+import Upload from 'rc-upload';
+
+const props = {
+  action: '/upload.do',
+  type: 'drag',
+  directory: 'nonClick' as 'nonClick',
+  beforeUpload(file, fileList) {
+    console.log('beforeUpload', file.name, fileList);
+  },
+  onStart: file => {
+    console.log('onStart', file.name);
+  },
+  onSuccess(file) {
+    console.log('onSuccess', file);
+  },
+  onProgress(step, file) {
+    console.log('onProgress', Math.round(step.percent), file.name);
+  },
+  onError(err) {
+    console.log('onError', err);
+  },
+  style: { display: 'inline-block', width: 200, height: 200, background: '#eee' },
+  // openFileDialogOnClick: false
+};
+
+const Test = () => {
+  return (
+    <div
+      style={{
+        margin: 100,
+      }}
+    >
+      <div>
+        <Upload {...props}>
+          <a>开始上传，只支持拖拽上传文件夹</a>
+        </Upload>
+      </div>
+    </div>
+  );
+};
+
+export default Test;

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -335,7 +335,7 @@ class AjaxUploader extends Component<UploadProps> {
     });
     // because input don't have directory/webkitdirectory type declaration
     const dirProps: any =
-      directory || folder ? { directory: 'directory', webkitdirectory: 'webkitdirectory' } : {};
+      directory === true || folder ? { directory: 'directory', webkitdirectory: 'webkitdirectory' } : {};
     const events = disabled
       ? {}
       : {

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -14,7 +14,7 @@ export interface UploadProps
   action?: Action;
   method?: UploadRequestMethod;
   /** @deprecated Please use `folder` instead */
-  directory?: boolean;
+  directory?: boolean | 'nonClick';
   folder?: boolean;
   data?: Record<string, unknown> | ((file: RcFile | string | Blob) => Record<string, unknown>);
   headers?: UploadRequestHeader;


### PR DESCRIPTION
支持拖拽、粘贴文件夹，点击时为非 `directory` 模式
<img width="972" height="447" alt="image" src="https://github.com/user-attachments/assets/0bbb3c35-1e59-48e3-a592-95dbc7b8328d" />
