### PR TITLE
feat: Add defaultRequest to customRequest

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -253,10 +253,9 @@ class AjaxUploader extends Component<UploadProps> {
 
     const { uid } = origin;
 
-    const request =
-      typeof propsCustomRequest === 'function'
-        ? args => propsCustomRequest(args, { defaultRequest })
-        : propsCustomRequest || defaultRequest;
+    const request = propsCustomRequest
+      ? args => propsCustomRequest(args, { defaultRequest })
+      : defaultRequest;
 
     const requestOption = {
       action,

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -253,13 +253,10 @@ class AjaxUploader extends Component<UploadProps> {
 
     const { uid } = origin;
 
-    const customRequest = agu => {
-      return propsCustomRequest({ ...agu, info: { defaultRequest } });
-    };
-
     const request =
-      (typeof propsCustomRequest === 'function' ? customRequest : propsCustomRequest) ||
-      defaultRequest;
+      typeof propsCustomRequest === 'function'
+        ? args => propsCustomRequest({ ...args, info: { defaultRequest } })
+        : propsCustomRequest || defaultRequest;
 
     const requestOption = {
       action,

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -255,7 +255,7 @@ class AjaxUploader extends Component<UploadProps> {
 
     const request =
       typeof propsCustomRequest === 'function'
-        ? args => propsCustomRequest({ ...args, info: { defaultRequest } })
+        ? args => propsCustomRequest(args, { defaultRequest })
         : propsCustomRequest || defaultRequest;
 
     const requestOption = {

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -242,20 +242,11 @@ class AjaxUploader extends Component<UploadProps> {
       return;
     }
 
-    const {
-      onStart,
-      customRequest: propsCustomRequest,
-      name,
-      headers,
-      withCredentials,
-      method,
-    } = this.props;
+    const { onStart, customRequest, name, headers, withCredentials, method } = this.props;
 
     const { uid } = origin;
 
-    const request = propsCustomRequest
-      ? args => propsCustomRequest(args, { defaultRequest })
-      : defaultRequest;
+    const request = customRequest || defaultRequest;
 
     const requestOption = {
       action,
@@ -284,7 +275,7 @@ class AjaxUploader extends Component<UploadProps> {
     };
 
     onStart(origin);
-    this.reqs[uid] = request(requestOption);
+    this.reqs[uid] = request(requestOption, { defaultRequest });
   }
 
   reset() {

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -242,10 +242,24 @@ class AjaxUploader extends Component<UploadProps> {
       return;
     }
 
-    const { onStart, customRequest, name, headers, withCredentials, method } = this.props;
+    const {
+      onStart,
+      customRequest: propsCustomRequest,
+      name,
+      headers,
+      withCredentials,
+      method,
+    } = this.props;
 
     const { uid } = origin;
-    const request = customRequest || defaultRequest;
+
+    const customRequest = agu => {
+      return propsCustomRequest({ ...agu, info: { defaultRequest } });
+    };
+
+    const request =
+      (typeof propsCustomRequest === 'function' ? customRequest : propsCustomRequest) ||
+      defaultRequest;
 
     const requestOption = {
       action,

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -31,7 +31,7 @@ export interface UploadProps
     file: RcFile,
     FileList: RcFile[],
   ) => BeforeUploadFileType | Promise<void | BeforeUploadFileType> | void;
-  customRequest?: (option: CustomUploadRequestOption) => void | { abort: () => void };
+  customRequest?: CustomUploadRequestOption;
   withCredentials?: boolean;
   openFileDialogOnClick?: boolean;
   prefixCls?: string;
@@ -78,11 +78,10 @@ export interface UploadRequestOption<T = any> {
   method: UploadRequestMethod;
 }
 
-export interface CustomUploadRequestOption extends UploadRequestOption {
-  info: {
-    defaultRequest: (option: UploadRequestOption) => { abort: () => void } | void;
-  };
-}
+export type CustomUploadRequestOption = (
+  option: UploadRequestOption,
+  info: { defaultRequest: (option: UploadRequestOption) => { abort: () => void } | void },
+) => void | { abort: () => void };
 export interface RcFile extends File {
   uid: string;
 }

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -31,7 +31,7 @@ export interface UploadProps
     file: RcFile,
     FileList: RcFile[],
   ) => BeforeUploadFileType | Promise<void | BeforeUploadFileType> | void;
-  customRequest?: (option: UploadRequestOption) => void | { abort: () => void };
+  customRequest?: (option: CustomUploadRequestOption) => void | { abort: () => void };
   withCredentials?: boolean;
   openFileDialogOnClick?: boolean;
   prefixCls?: string;
@@ -78,6 +78,11 @@ export interface UploadRequestOption<T = any> {
   method: UploadRequestMethod;
 }
 
+export interface CustomUploadRequestOption extends UploadRequestOption {
+  info: {
+    defaultRequest: (option: UploadRequestOption) => { abort: () => void } | void;
+  };
+}
 export interface RcFile extends File {
   uid: string;
 }

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -1267,11 +1267,9 @@ describe('uploader', () => {
     expect(container.querySelector('span')!).not.toHaveAttribute('role', 'button');
   });
   it('should support defaultRequest in customRequest', done => {
-    const mockDefaultRequest = jest.fn();
     const customRequest = jest.fn(({ file, onSuccess, onError, info }) => {
       // 模拟条件判断后使用默认上传
       if (file.name === 'success.png') {
-        info.defaultRequest = mockDefaultRequest;
         info.defaultRequest({ file, onSuccess, onError });
       } else {
         onError(new Error('custom error'));
@@ -1293,11 +1291,6 @@ describe('uploader', () => {
       setTimeout(() => {
         expect(customRequest).toHaveBeenCalled();
         expect(onSuccess).toHaveBeenCalled();
-        expect(mockDefaultRequest).toHaveBeenCalledWith({
-          file: expect.any(File),
-          onSuccess: expect.any(Function),
-          onError: expect.any(Function),
-        });
         done();
       }, 100);
     }, 100);

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -1267,10 +1267,9 @@ describe('uploader', () => {
     expect(container.querySelector('span')!).not.toHaveAttribute('role', 'button');
   });
   it('should support defaultRequest in customRequest', done => {
-    const customRequest = jest.fn(({ file, onSuccess, onError, info }) => {
-      // 模拟条件判断后使用默认上传
+    const customRequest = jest.fn(({ file, onSuccess, onError }, { defaultRequest }) => {
       if (file.name === 'success.png') {
-        info.defaultRequest({ file, onSuccess, onError });
+        defaultRequest({ file, onSuccess, onError });
       } else {
         onError(new Error('custom error'));
       }
@@ -1286,13 +1285,12 @@ describe('uploader', () => {
       value: i => files[i],
     });
     fireEvent.change(input, { target: { files } });
+
     setTimeout(() => {
       requests[0].respond(200, {}, `["","${files[0].name}"]`);
-      setTimeout(() => {
-        expect(customRequest).toHaveBeenCalled();
-        expect(onSuccess).toHaveBeenCalled();
-        done();
-      }, 100);
+      expect(customRequest).toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+      done();
     }, 100);
   });
 });


### PR DESCRIPTION
关联issue： https://github.com/ant-design/ant-design/issues/54457
在customRequest 参数中增加 defaultRequest 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 上传组件的 customRequest 在被调用时额外收到 info.defaultRequest，允许在自定义逻辑中回退或委托到内置上传流程，提升可定制性与可控性。
- 类型
  - 新增并导出用于 customRequest 的公共类型，改善 TypeScript 提示与开发体验。
- 测试
  - 新增测试，验证在 customRequest 中调用 defaultRequest 能触发并完成上传回调流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->