### PR TITLE
fix: uid conflict when multiple upload components paste at same time

### DIFF
--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -96,12 +96,12 @@ class AjaxUploader extends Component<UploadProps> {
 
     const items: DataTransferItem[] = [...(dataTransfer.items || [])];
     // Clone File objects to avoid shared uid mutation between multiple Upload components
-    let files: File[] = [...(dataTransfer.files || [])].map(file => (
+    let files: File[] = Array.from(dataTransfer.files ?? [], file =>
       new File([file], file.name, {
         type: file.type,
         lastModified: file.lastModified,
       })
-    ));
+    );
 
     if (files.length > 0 || items.some(item => item.kind === 'file')) {
       existFileCallback?.();

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -95,6 +95,7 @@ class AjaxUploader extends Component<UploadProps> {
     const { multiple, directory } = this.props;
 
     const items: DataTransferItem[] = [...(dataTransfer.items || [])];
+    // Clone File objects to avoid shared uid mutation between multiple Upload components
     let files: File[] = [...(dataTransfer.files || [])].map(file => (
       new File([file], file.name, {
         type: file.type,

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -95,12 +95,12 @@ class AjaxUploader extends Component<UploadProps> {
     const { multiple, directory } = this.props;
 
     const items: DataTransferItem[] = [...(dataTransfer.items || [])];
-    let files: File[] = [...(dataTransfer.files || [])].map((file: File) => {
-      return new File([file], file.name, {
+    let files: File[] = [...(dataTransfer.files || [])].map(file => (
+      new File([file], file.name, {
         type: file.type,
         lastModified: file.lastModified,
-      });
-    });
+      })
+    ));
 
     if (files.length > 0 || items.some(item => item.kind === 'file')) {
       existFileCallback?.();

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -95,7 +95,12 @@ class AjaxUploader extends Component<UploadProps> {
     const { multiple, directory } = this.props;
 
     const items: DataTransferItem[] = [...(dataTransfer.items || [])];
-    let files: File[] = [...(dataTransfer.files || [])];
+    let files: File[] = [...(dataTransfer.files || [])].map((file: File) => {
+      return new File([file], file.name, {
+        type: file.type,
+        lastModified: file.lastModified,
+      });
+    });
 
     if (files.length > 0 || items.some(item => item.kind === 'file')) {
       existFileCallback?.();
@@ -296,7 +301,6 @@ class AjaxUploader extends Component<UploadProps> {
         delete this.reqs[uid];
       },
     };
-
     onStart(origin);
     this.reqs[uid] = request(requestOption, { defaultRequest });
   }

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -526,126 +526,62 @@ describe('uploader', () => {
     });
 
     it('should prevent uid overwritten when multiple upload components paste simultaneously', async () => {
-      const handlers1: UploadProps = {};
-      const handlers2: UploadProps = {};
+      const uidsInBeforeUpload: string[] = [];
+      const uidsInOnStart: string[] = [];
+      const uidsInOnSuccess: string[] = [];
 
-      const props1: UploadProps = {
+      const createUploadProps = (index: number): UploadProps => ({
         ...props,
-        beforeUpload(file, fileList) {
-          if (handlers1.beforeUpload) {
-            return handlers1.beforeUpload(file, fileList);
-          }
+        pastable: true,
+        beforeUpload(file) {
+          uidsInBeforeUpload[index] = file.uid;
           return true;
         },
         onStart(file) {
-          if (handlers1.onStart) {
-            handlers1.onStart(file);
-          }
+          uidsInOnStart[index] = file.uid;
         },
         onSuccess(ret, file) {
-          if (handlers1.onSuccess) {
-            handlers1.onSuccess(ret, file, null!);
-          }
+          uidsInOnSuccess[index] = file.uid;
         },
-        onError(err, result, file) {
-          if (handlers1.onError) {
-            handlers1.onError(err, result, file);
-          }
+        onError(err) {
+          throw err;
         },
-      };
+      });
 
-      const props2: UploadProps = {
-        ...props,
-        beforeUpload(file, fileList) {
-          if (handlers2.beforeUpload) {
-            return handlers2.beforeUpload(file, fileList);
-          }
-          return true;
-        },
-        onStart(file) {
-          if (handlers2.onStart) {
-            handlers2.onStart(file);
-          }
-        },
-        onSuccess(ret, file) {
-          if (handlers2.onSuccess) {
-            handlers2.onSuccess(ret, file, null!);
-          }
-        },
-        onError(err, result, file) {
-          if (handlers2.onError) {
-            handlers2.onError(err, result, file);
-          }
-        },
-      };
-
-      let uid1: string | undefined;
-      handlers1.beforeUpload = (file, fileList) => {
-        expect(file).toHaveProperty('uid');
-        uid1 = file.uid;
-        return true;
-      };
-      handlers1.onStart = file => {
-        expect(file).toHaveProperty('uid');
-        expect(file.uid).toEqual(uid1);
-      };
-      handlers1.onSuccess = (ret, file) => {
-        expect(ret[1]).toEqual(file.name);
-        expect(file).toHaveProperty('uid');
-        expect(file.uid).toEqual(uid1);
-      };
-      handlers1.onError = (err, result, file) => {
-        expect(file).toHaveProperty('uid');
-        expect(file.uid).toEqual(uid1);
-        throw err;
-      };
-
-      let uid2: string | undefined;
-      handlers2.beforeUpload = (file, fileList) => {
-        expect(file).toHaveProperty('uid');
-        uid2 = file.uid;
-        return true;
-      };
-      handlers2.onStart = file => {
-        expect(file).toHaveProperty('uid');
-        expect(file.uid).toEqual(uid2);
-      };
-      handlers2.onSuccess = (ret, file) => {
-        expect(ret[1]).toEqual(file.name);
-        expect(file).toHaveProperty('uid');
-        expect(file.uid).toEqual(uid2);
-      };
-      handlers2.onError = (err, result, file) => {
-        expect(file).toHaveProperty('uid');
-        expect(file.uid).toEqual(uid2);
-        throw err;
-      };
-
-      const { container: container } = render(<Upload {...props1} pastable />);
-      render(<Upload {...props2} pastable />);
+      const { container } = render(<Upload {...createUploadProps(0)} />);
+      render(<Upload {...createUploadProps(1)} />);
 
       const input = container.querySelector('input')!;
-
-      const files = [
-        new File([''], 'success.png', { type: 'image/png' }),
-      ];
+      const files = [new File([''], 'success.png', { type: 'image/png' })];
       Object.defineProperty(files, 'item', {
         value: i => files[i],
       });
 
-      fireEvent.paste(input, {
-        clipboardData: { files },
-      });
+      fireEvent.paste(input, { clipboardData: { files } });
 
       await sleep(100);
 
-      expect(requests).toHaveLength(2);
-      expect(uid1).toBeDefined();
-      expect(uid2).toBeDefined();
-      expect(uid1).not.toEqual(uid2);
+      expect(uidsInBeforeUpload[0]).toBeDefined();
+      expect(uidsInBeforeUpload[1]).toBeDefined();
+      expect(uidsInBeforeUpload[0]).not.toEqual(uidsInBeforeUpload[1]);
 
+      expect(uidsInOnStart[0]).toBeDefined();
+      expect(uidsInOnStart[1]).toBeDefined();
+      expect(uidsInOnStart[0]).not.toEqual(uidsInOnStart[1]);
+
+      expect(uidsInOnStart[0]).toEqual(uidsInBeforeUpload[0]);
+      expect(uidsInOnStart[1]).toEqual(uidsInBeforeUpload[1]);
+
+      expect(requests).toHaveLength(2);
       requests[0].respond(200, {}, `["","${files[0].name}"]`);
       requests[1].respond(200, {}, `["","${files[0].name}"]`);
+
+      expect(uidsInOnSuccess[0]).toBeDefined();
+      expect(uidsInOnSuccess[1]).toBeDefined();
+      expect(uidsInOnSuccess[0]).not.toEqual(uidsInOnSuccess[1]);
+      
+      expect(uidsInOnSuccess[0]).toEqual(uidsInBeforeUpload[0]);
+      expect(uidsInOnSuccess[1]).toEqual(uidsInBeforeUpload[1]);
     });
   });
 

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -638,7 +638,14 @@ describe('uploader', () => {
       });
 
       await sleep(100);
+
+      expect(requests).toHaveLength(2);
+      expect(uid1).toBeDefined();
+      expect(uid2).toBeDefined();
+      expect(uid1).not.toEqual(uid2);
+
       requests[0].respond(200, {}, `["","${files[0].name}"]`);
+      requests[1].respond(200, {}, `["","${files[0].name}"]`);
     });
   });
 

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -318,7 +318,7 @@ describe('uploader', () => {
       Object.defineProperty(files, 'item', {
         value: i => files[i],
       });
-
+      
       // Only can trigger once
       let triggerTimes = 0;
       handlers.onStart = () => {
@@ -345,7 +345,7 @@ describe('uploader', () => {
       fireEvent.drop(input, { dataTransfer: { files } });
 
       setTimeout(() => {
-        handlers.onSuccess!(['', files[0].name] as any, files[0] as any, null!);
+        requests[0].respond(200, {}, `["","${files[0].name}"]`);
       }, 100);
     });
 
@@ -432,7 +432,7 @@ describe('uploader', () => {
       fireEvent.paste(input, { clipboardData: { files } });
 
       await sleep(100);
-      handlers.onSuccess!(['', files[0].name] as any, files[0] as any, null!);
+      requests[0].respond(200, {}, `["","${files[0].name}"]`);
     });
 
     it('support action and data is function returns Promise', async () => {
@@ -523,6 +523,122 @@ describe('uploader', () => {
 
       expect(preventDefaultSpy).toHaveBeenCalledTimes(0);
       preventDefaultSpy.mockRestore();
+    });
+
+    it('should prevent uid overwritten when multiple upload components paste simultaneously', async () => {
+      const handlers1: UploadProps = {};
+      const handlers2: UploadProps = {};
+
+      const props1: UploadProps = {
+        ...props,
+        beforeUpload(file, fileList) {
+          if (handlers1.beforeUpload) {
+            return handlers1.beforeUpload(file, fileList);
+          }
+          return true;
+        },
+        onStart(file) {
+          if (handlers1.onStart) {
+            handlers1.onStart(file);
+          }
+        },
+        onSuccess(ret, file) {
+          if (handlers1.onSuccess) {
+            handlers1.onSuccess(ret, file, null!);
+          }
+        },
+        onError(err, result, file) {
+          if (handlers1.onError) {
+            handlers1.onError(err, result, file);
+          }
+        },
+      };
+
+      const props2: UploadProps = {
+        ...props,
+        beforeUpload(file, fileList) {
+          if (handlers2.beforeUpload) {
+            return handlers2.beforeUpload(file, fileList);
+          }
+          return true;
+        },
+        onStart(file) {
+          if (handlers2.onStart) {
+            handlers2.onStart(file);
+          }
+        },
+        onSuccess(ret, file) {
+          if (handlers2.onSuccess) {
+            handlers2.onSuccess(ret, file, null!);
+          }
+        },
+        onError(err, result, file) {
+          if (handlers2.onError) {
+            handlers2.onError(err, result, file);
+          }
+        },
+      };
+
+      let uid1: string | undefined;
+      handlers1.beforeUpload = (file, fileList) => {
+        expect(file).toHaveProperty('uid');
+        uid1 = file.uid;
+        return true;
+      };
+      handlers1.onStart = file => {
+        expect(file).toHaveProperty('uid');
+        expect(file.uid).toEqual(uid1);
+      };
+      handlers1.onSuccess = (ret, file) => {
+        expect(ret[1]).toEqual(file.name);
+        expect(file).toHaveProperty('uid');
+        expect(file.uid).toEqual(uid1);
+      };
+      handlers1.onError = (err, result, file) => {
+        expect(file).toHaveProperty('uid');
+        expect(file.uid).toEqual(uid1);
+        throw err;
+      };
+
+      let uid2: string | undefined;
+      handlers2.beforeUpload = (file, fileList) => {
+        expect(file).toHaveProperty('uid');
+        uid2 = file.uid;
+        return true;
+      };
+      handlers2.onStart = file => {
+        expect(file).toHaveProperty('uid');
+        expect(file.uid).toEqual(uid2);
+      };
+      handlers2.onSuccess = (ret, file) => {
+        expect(ret[1]).toEqual(file.name);
+        expect(file).toHaveProperty('uid');
+        expect(file.uid).toEqual(uid2);
+      };
+      handlers2.onError = (err, result, file) => {
+        expect(file).toHaveProperty('uid');
+        expect(file.uid).toEqual(uid2);
+        throw err;
+      };
+
+      const { container: container } = render(<Upload {...props1} pastable />);
+      render(<Upload {...props2} pastable />);
+
+      const input = container.querySelector('input')!;
+
+      const files = [
+        new File([''], 'success.png', { type: 'image/png' }),
+      ];
+      Object.defineProperty(files, 'item', {
+        value: i => files[i],
+      });
+
+      fireEvent.paste(input, {
+        clipboardData: { files },
+      });
+
+      await sleep(100);
+      requests[0].respond(200, {}, `["","${files[0].name}"]`);
     });
   });
 


### PR DESCRIPTION
修复多个上传组件同时粘贴上传会覆写 dataTransfer 中文件的 uid，导致文件状态更新异常的问题。
<img width="2535" height="890" alt="image" src="https://github.com/user-attachments/assets/6071f018-a1ee-4cf4-9062-370ca5d44fda" />
图中两个文件上传都失败了，但是第一个文件始终处于 uploading 状态


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复粘贴/拖拽场景中文件实例共享导致的标识冲突：对粘贴/拖拽接收的文件进行重建并保留名称、类型和修改时间，提升并发操作下的元数据一致性与稳定性。

* **Tests**
  * 新增并发粘贴/上传场景测试，验证不同上传组件同时操作时各上传项的唯一标识稳定且互不干扰。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->