### PR TITLE
Avoid util deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "test": "rc-test"
   },
   "dependencies": {
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.4",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^16.2.0",

--- a/src/AjaxUploader.tsx
+++ b/src/AjaxUploader.tsx
@@ -1,5 +1,5 @@
 /* eslint react/no-is-mounted:0,react/sort-comp:0,react/prop-types:0 */
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 import React, { Component } from 'react';
 import attrAccept from './attr-accept';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
-import type { UploadProps } from './interface';
+import type {
+  AcceptConfig,
+  RcFile,
+  UploadProps,
+  UploadRequestOption,
+} from './interface';
 import Upload from './Upload';
 
-export type { UploadProps };
+export type { AcceptConfig, RcFile, UploadProps, UploadRequestOption };
 
 export default Upload;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,15 @@
 import type {
   AcceptConfig,
-  BeforeUploadFileType,
-  CustomUploadRequestOption,
   RcFile,
-  UploadProgressEvent,
   UploadProps,
-  UploadRequestError,
   UploadRequestOption,
 } from './interface';
 import Upload from './Upload';
 
 export type {
   AcceptConfig,
-  BeforeUploadFileType,
-  CustomUploadRequestOption,
   RcFile,
-  UploadProgressEvent,
   UploadProps,
-  UploadRequestError,
   UploadRequestOption,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,24 @@
 import type {
   AcceptConfig,
+  BeforeUploadFileType,
+  CustomUploadRequestOption,
   RcFile,
+  UploadProgressEvent,
   UploadProps,
+  UploadRequestError,
   UploadRequestOption,
 } from './interface';
 import Upload from './Upload';
 
-export type { AcceptConfig, RcFile, UploadProps, UploadRequestOption };
+export type {
+  AcceptConfig,
+  BeforeUploadFileType,
+  CustomUploadRequestOption,
+  RcFile,
+  UploadProgressEvent,
+  UploadProps,
+  UploadRequestError,
+  UploadRequestOption,
+};
 
 export default Upload;

--- a/tests/uploader.spec.tsx
+++ b/tests/uploader.spec.tsx
@@ -1,4 +1,4 @@
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import sinon from 'sinon';


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到当前 latest `^1.11.1`。
- 升级 `@rc-component/father-plugin` 到 `^2.2.0`，交由插件统一处理 rc 深路径 import 限制。
- 将源码和测试中对 `@rc-component/util/lib/*` 的引用改为从 `@rc-component/util` 根入口导入。
- 从根入口补充导出 `AcceptConfig`、`RcFile`、`UploadRequestOption` 等上传相关类型。

## 背景

配合 rc 包统一避免依赖其他 rc 包的 `es` / `lib` 构建产物内部路径，改为使用公开根入口 API。

## 验证

- `git diff --check`
- 此前批量调整中已跑通 `npm run compile`、`npm run lint`、`npm test`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 升级若干内部依赖以保持构建工具和运行时的稳定性与兼容性。

* **其他改进**
  * 扩展并重新导出更多公开类型，便于直接访问更完整的类型定义。
  * 优化若干模块和测试的导入方式，改善代码组织与维护体验。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/upload/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->