### PR TITLE
Specialize interface file types.

### DIFF
--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -24,7 +24,7 @@ export interface UploadProps
   accept?: string | AcceptConfig;
   multiple?: boolean;
   onBatchStart?: (
-    fileList: { file: RcFile; parsedFile: Exclude<BeforeUploadFileType, boolean> }[],
+    fileList: { file: RcFile; parsedFile: RcFile }[],
   ) => void;
   onStart?: (file: RcFile) => void;
   onError?: (error: Error, ret: Record<string, unknown>, file: RcFile) => void;
@@ -60,7 +60,7 @@ export type UploadRequestMethod = 'POST' | 'PUT' | 'PATCH' | 'post' | 'put' | 'p
 
 export type UploadRequestHeader = Record<string, string>;
 
-export type UploadRequestFile = Exclude<BeforeUploadFileType, File | boolean> | RcFile;
+export type UploadRequestFile = RcFile;
 
 export interface UploadRequestError extends Error {
   status?: number;


### PR DESCRIPTION
Files are always parsed into RcFile before being passed to these functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 优化了文件上传功能的类型定义，增强了代码的类型安全性和一致性，改进了基础架构的可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/upload/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->